### PR TITLE
Fixes a memory leak in utkscan

### DIFF
--- a/Scan/utkscan/core/source/RawEvent.cpp
+++ b/Scan/utkscan/core/source/RawEvent.cpp
@@ -31,6 +31,10 @@ void RawEvent::Zero(const std::set<std::string> &usedev) {
         (*it).second.Zero();
     }
 
+    for(vector<ChanEvent*>::iterator it = eventList.begin();
+                it != eventList.end(); it++)
+        delete *it;
+
     eventList.clear();
 }
 

--- a/Scan/utkscan/core/source/UtkUnpacker.cpp
+++ b/Scan/utkscan/core/source/UtkUnpacker.cpp
@@ -33,7 +33,7 @@ UtkUnpacker::~UtkUnpacker() {
 void UtkUnpacker::ProcessRawEvent(ScanInterface *addr_/*=NULL*/){
     if(!addr_)
         return;
-    
+
     DetectorDriver* driver = DetectorDriver::get();
     DetectorLibrary* modChan = DetectorLibrary::get();
     XiaData *current_event = NULL;


### PR DESCRIPTION
This memory leak causes the software to use all of the available memory and eventually crashes the computer. This may be related to issue #24, but that is unconfirmed at this point.
