### PR TITLE
pread/write uses ranges and reads hex input.

### DIFF
--- a/Poll/include/poll2_core.h
+++ b/Poll/include/poll2_core.h
@@ -235,6 +235,13 @@ class Poll{
 	/// Broadcast a data spill onto the network in the classic pacman format.
 	void broadcast_pac_data();
 
+	/// @brief Splits the arguments to pread and pwrite on a colon delimeter.
+	/// @param[in] arg The argument to be split.
+	/// @param[out] start The first value in the string indicating the first mod / ch.
+	/// @param[out] start The second value in the string indicating the last mod / ch.
+	/// @return Whether the attempt was succesful.
+	bool SplitParameterArgs(const std::string &arg, int &start, int &stop);
+
   public:
   	/// Default constructor.
 	Poll();


### PR DESCRIPTION
Added the capability to specify modules or channels with a colon character delimiting a range. For example,
`pwrite 0 0:4 TRIGGER_THRESHOLD 0x1a`
would set the trigger threshold for module 0 and channels 0-4 to the hex value 0x1a (decimal 26).
