### PR TITLE
Removed PLD_header delete statement

### DIFF
--- a/Core/source/hribf_buffers.cpp
+++ b/Core/source/hribf_buffers.cpp
@@ -101,7 +101,6 @@ PLD_header::PLD_header() : BufferType(HEAD, 0){ // 0x44414548 "HEAD"
 
 /// Destructor.
 PLD_header::~PLD_header(){
-	if(run_title){ delete[] run_title; }
 }
 
 /// Get the length of the header buffer.


### PR DESCRIPTION
PLD_header::~PLD_header had an uneeded delete statement. This was causing a seg fault when quitting poll2 on nitemp.
