### PR TITLE
Mod / Chan Range and Hex Input

### DIFF
--- a/Poll/source/poll2_core.cpp
+++ b/Poll/source/poll2_core.cpp
@@ -837,7 +837,7 @@ void Poll::get_traces(int mod_, int chan_, int thresh_/*=0*/){
 /// If the attmept is unsuccesful the mehtod returns false.
 bool Poll::SplitParameterArgs(const std::string &arg, int &start, int &stop) {
 	//If a character is found that is nonnumeric or is not the delimeter we stop.
-	if (arg.find_first_not_of("0123456789:") != std::string::npos) return false;
+	if (arg.find_first_not_of("-0123456789:") != std::string::npos) return false;
 
 	size_t delimeterPos = arg.find(':');
 	try {	
@@ -845,6 +845,7 @@ bool Poll::SplitParameterArgs(const std::string &arg, int &start, int &stop) {
 		//If the delimeter was found we can seperate the stop otherwise set start = stop.
 		if (delimeterPos != std::string::npos) {
 			stop = std::stoi(arg.substr(delimeterPos + 1));
+			if (start < 0 || stop < 0 || start > stop) return false;
 		}
 		else stop = start;
 	}

--- a/Poll/source/poll2_core.cpp
+++ b/Poll/source/poll2_core.cpp
@@ -1308,8 +1308,24 @@ void Poll::CommandControl(){
 		else if(cmd == "csr_test"){ // Run CSRAtest method
 			BitFlipper flipper;
 			if(p_args >= 1){ 
-				if(!IsNumeric(arguments.at(0), sys_message_head, "Invalid CSRA value specification")) continue;
-				flipper.CSRAtest((unsigned int)atoi(arguments.at(0).c_str())); 
+				//Check that there are no characters in the string unless it is hex.
+				std::string &valueStr = arguments.at(0);
+				if (valueStr.find_last_not_of("0123456789") != std::string::npos &&
+						!((valueStr.find("0x") == 0 || valueStr.find("0X") == 0) &&
+							valueStr.find_first_not_of("0123456789abcdefABCDEF", 2) == std::string::npos) ) {
+					std::cout << "ERROR: Invalid parameter value: '" << valueStr << "'\n";
+					continue;
+				}
+				unsigned int value;
+				//Use stod to add hex capability. The decimal and negative values are
+				// caught above and rejected.
+				try { value = (unsigned int) std::stod(valueStr); }
+				catch (const std::invalid_argument &ia) {
+					std::cout << "ERROR: Invalid parameter value: '" << valueStr << "'\n";
+					continue;
+				}
+
+				flipper.CSRAtest(value);
 			}
 			else{
 				std::cout << sys_message_head << "Invalid number of parameters to csr_test\n";

--- a/Poll/source/poll2_core.cpp
+++ b/Poll/source/poll2_core.cpp
@@ -1204,11 +1204,16 @@ void Poll::CommandControl(){
 			}
 
 			if(p_args >= 1){
-				if(!IsNumeric(arguments.at(0), sys_message_head, "Invalid module specification")) continue;
-				int mod = atoi(arguments.at(0).c_str());
-				
+				int modStart, modStop;
+				if (!SplitParameterArgs(arguments.at(0), modStart, modStop)) {
+					std::cout << "ERROR: Invalid module argument: '" << arguments.at(0) << "'\n";
+					continue;
+				}
+
 				OffsetAdjuster adjuster;
-				if(forModule(pif, mod, adjuster, 0)){ pif->SaveDSPParameters(); }
+				for (int mod = modStart; mod <= modStop; mod++) {
+					if(forModule(pif, mod, adjuster, 0)){ pif->SaveDSPParameters(); }
+				}
 			}
 			else{
 				std::cout << sys_message_head << "Invalid number of parameters to adjust_offsets\n";

--- a/Poll/source/poll2_core.cpp
+++ b/Poll/source/poll2_core.cpp
@@ -1249,14 +1249,28 @@ void Poll::CommandControl(){
 			BitFlipper flipper;
 
 			if(p_args >= 3){ 
-				if(!IsNumeric(arguments.at(0), sys_message_head, "Invalid module specification")) continue;
-				else if(!IsNumeric(arguments.at(1), sys_message_head, "Invalid channel specification")) continue;
+				int modStart, modStop;
+				if (!SplitParameterArgs(arguments.at(0), modStart, modStop)) {
+					std::cout << "ERROR: Invalid module argument: '" << arguments.at(0) << "'\n";
+					continue;
+				}
+				int chStart, chStop;
+				if (!SplitParameterArgs(arguments.at(1), chStart, chStop)) {
+					std::cout << "ERROR: Invalid channel argument: '" << arguments.at(1) << "'\n";
+					continue;
+				}
 				flipper.SetCSRAbit(arguments.at(2));
 				
 				std::string dum_str = "CHANNEL_CSRA";
-				if(forChannel(pif, atoi(arguments.at(0).c_str()), atoi(arguments.at(1).c_str()), flipper, dum_str)){
-					pif->SaveDSPParameters();
+				bool error = false;
+				for (int mod = modStart; mod <= modStop; mod++) {
+					for (int ch = chStart; ch <= chStop; ch++) {
+						if(!forChannel(pif, mod, ch, flipper, dum_str)){
+							error = true;
+						}
+					}
 				}
+				if (!error) pif->SaveDSPParameters();
 			}
 			else{
 				std::cout << sys_message_head << "Invalid number of parameters to toggle\n";

--- a/Poll/source/poll2_core.cpp
+++ b/Poll/source/poll2_core.cpp
@@ -1133,11 +1133,13 @@ void Poll::CommandControl(){
 					}
 
 					ParameterModuleWriter writer;
+					bool error = false;
 					for (int mod = modStart; mod <= modStop; mod++) {
-						if(forModule(pif, mod, writer, make_pair(arguments.at(1), value))){
-							pif->SaveDSPParameters();
+						if(!forModule(pif, mod, writer, make_pair(arguments.at(1), value))){
+							error = true;
 						}
 					}
+					if (!error) pif->SaveDSPParameters();
 				}
 				else{
 					std::cout << sys_message_head << "Invalid number of parameters to pmwrite\n";
@@ -1211,9 +1213,11 @@ void Poll::CommandControl(){
 				}
 
 				OffsetAdjuster adjuster;
+				bool error = false;
 				for (int mod = modStart; mod <= modStop; mod++) {
-					if(forModule(pif, mod, adjuster, 0)){ pif->SaveDSPParameters(); }
+					if(!forModule(pif, mod, adjuster, 0)){ error = true; }
 				}
+				if (!error) pif->SaveDSPParameters();
 			}
 			else{
 				std::cout << sys_message_head << "Invalid number of parameters to adjust_offsets\n";


### PR DESCRIPTION
Updated pmread / pmwrite, adjust_offests, toggle, and csr_test to read ranges of modules or channels and hexadecimal input.

This addresses and resolves issue #139 