### PR TITLE
Updated CTerminalTest to display TERM.

### DIFF
--- a/Core/tests/CMakeLists.txt
+++ b/Core/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(CTerminalTest CTerminalTest.cpp)
-target_link_libraries(CTerminalTest PixieCore)
+target_link_libraries(CTerminalTest PixieCoreStatic)
 install (TARGETS CTerminalTest DESTINATION bin)

--- a/Core/tests/CTerminalTest.cpp
+++ b/Core/tests/CTerminalTest.cpp
@@ -16,6 +16,7 @@ int main(int argc, char *argv[]){
 	Terminal term;
 	term.Initialize();
 	std::cout << "This is test terminal.\n" ;
+	std::cout << "$TERM: " << std::getenv("TERM") << "\n";
 
 	term.SetCommandHistory("CTerminalTest.cmd");
 	term.SetPrompt("Test> ");


### PR DESCRIPTION
The CTerminalTest program now displays the TERM environment variable when starting.
Also, changed to static library linkage.