### PR TITLE
Added GetOutputName to globals

### DIFF
--- a/Scan/utkscan/core/include/Globals.hpp
+++ b/Scan/utkscan/core/include/Globals.hpp
@@ -273,7 +273,6 @@ public:
     /*! \return returns name of specified output file */
     std::string outputFile() const {return outputFilename_;}
 
-
     /*! \return path to use to output files, can be different from output
      * file path
      * \param [in] fileName : the path for the configuration files */

--- a/Scan/utkscan/core/include/Globals.hpp
+++ b/Scan/utkscan/core/include/Globals.hpp
@@ -270,6 +270,10 @@ public:
                                TrapFilterParameters(125, 125, 10)));
     }
 
+    /*! \return returns name of specified output file */
+    std::string outputFile() const {return outputFilename_;}
+
+
     /*! \return path to use to output files, can be different from output
      * file path
      * \param [in] fileName : the path for the configuration files */
@@ -293,6 +297,10 @@ public:
      * Values should be given in seconds in respect to the beginning
      of the file */
     std::vector<std::pair<int, int> > rejectRegions() const { return reject_; };
+
+    /*! Sets output Filename from scan interface */
+    void SetOutputFilename(const std::string &a){outputFilename_ = a; }
+
 private:
     /** Default Constructor */
     Globals(const std::string &file);
@@ -339,6 +347,7 @@ private:
     std::map<std::string, std::pair<double, double> > cfdPars_; //!< Map containing all of the parameters to be used in the cfd analyzer for a type:subtype
     std::map<std::string, std::pair<TrapFilterParameters, TrapFilterParameters> > trapFiltPars_; //!<Map containing all of the trapezoidal filter parameters for a given type:subtype
 
+    std::string outputFilename_; //!<Output Filename
     std::string configFile_;//!< The configuration file
     std::string outputPath_;//!< The path to additional configuration files
     std::string revision_;//!< the pixie revision

--- a/Scan/utkscan/core/source/UtkScanInterface.cpp
+++ b/Scan/utkscan/core/source/UtkScanInterface.cpp
@@ -75,7 +75,6 @@ bool UtkScanInterface::Initialize(std::string prefix_) {
         output_his = new OutputHisFile(GetOutputFilename().c_str());
         output_his->SetDebugMode(false);
 
-
         Globals::get()->SetOutputFilename(GetOutputFilename());
 
         /** The DetectorDriver constructor will load processors

--- a/Scan/utkscan/core/source/UtkScanInterface.cpp
+++ b/Scan/utkscan/core/source/UtkScanInterface.cpp
@@ -75,6 +75,9 @@ bool UtkScanInterface::Initialize(std::string prefix_) {
         output_his = new OutputHisFile(GetOutputFilename().c_str());
         output_his->SetDebugMode(false);
 
+
+        Globals::get()->SetOutputFilename(GetOutputFilename());
+
         /** The DetectorDriver constructor will load processors
          *  from the xml configuration file upon first call.
          *  The DeclarePlots function will instantiate the DetectorLibrary


### PR DESCRIPTION
This replaces the old GetArguments way of using the .his name as the name of the created root file. I have been using this on my branches for a while now with no issues. 