### PR TITLE
Removing throw for Bad Event Length error

### DIFF
--- a/Scan/ScanLib/source/XiaListModeDataDecoder.cpp
+++ b/Scan/ScanLib/source/XiaListModeDataDecoder.cpp
@@ -98,9 +98,9 @@ vector<XiaData *> XiaListModeDataDecoder::DecodeBuffer(
                      << "Unexpected header length: " << headerLength << endl
                      << "ReadBuffer:   Buffer " << modNum << " of length "
                      << bufLen << endl
-                     << "ReadBuffer:   CRATE:SLOT:CHAN "
+                     << "ReadBuffer:   CRATE:SLOT(MOD):CHAN "
                      << data->GetCrateNumber() << ":"
-                     << data->GetSlotNumber() << ":"
+                     << data->GetSlotNumber() << "(" << modNum << "):"
                      << data->GetChannelNumber() << endl;
                 return vector<XiaData *>();
         }

--- a/Scan/ScanLib/tests/unittest-XiaListModeDataDecoder.cpp
+++ b/Scan/ScanLib/tests/unittest-XiaListModeDataDecoder.cpp
@@ -47,8 +47,8 @@ TEST_FIXTURE(XiaListModeDataDecoder, TestHeaderDecoding) {
 
 //Test if we can decode a trace properly
 TEST_FIXTURE(XiaListModeDataDecoder, TestTraceDecoding) {
-    //Check that we throw length_error when the event length doesn't match.
-    CHECK_THROW(DecodeBuffer(&header_w_bad_eventlen[0], mask), length_error);
+    //Now doing this just to view the error message
+    DecodeBuffer(&header_w_bad_eventlen[0], mask);
 
     XiaData result = *(DecodeBuffer(&header_N_trace[0], mask).front());
     CHECK_ARRAY_EQUAL(unittest_trace_variables::trace, result.GetTrace(),

--- a/Scan/ScanLib/tests/unittest-XiaListModeDataDecoder.cpp
+++ b/Scan/ScanLib/tests/unittest-XiaListModeDataDecoder.cpp
@@ -31,8 +31,9 @@ TEST_FIXTURE(XiaListModeDataDecoder, TestBufferLengthChecks) {
 ///Test if we can decode a simple 4 word header that includes the Pixie
 /// Module Data Header.
 TEST_FIXTURE(XiaListModeDataDecoder, TestHeaderDecoding) {
-    //Check for length_error when the header has an impossible size.
-    CHECK_THROW(DecodeBuffer(&header_w_bad_headerlen[0], mask), length_error);
+    //Check that we get an empty vector when the header has an impossible size.
+    CHECK_EQUAL((unsigned int)0,
+                DecodeBuffer(&header_w_bad_headerlen[0], mask).size());
 
     //Check that we can decode a simple 4-word header.
     XiaData result_data = *(DecodeBuffer(&header[0], mask).front());
@@ -47,8 +48,9 @@ TEST_FIXTURE(XiaListModeDataDecoder, TestHeaderDecoding) {
 
 //Test if we can decode a trace properly
 TEST_FIXTURE(XiaListModeDataDecoder, TestTraceDecoding) {
-    //Now doing this just to view the error message
-    DecodeBuffer(&header_w_bad_eventlen[0], mask);
+    //Testing that we return an empty event list.
+    CHECK_EQUAL((unsigned int)0,
+                DecodeBuffer(&header_w_bad_eventlen[0], mask).size());
 
     XiaData result = *(DecodeBuffer(&header_N_trace[0], mask).front());
     CHECK_ARRAY_EQUAL(unittest_trace_variables::trace, result.GetTrace(),


### PR DESCRIPTION
Due to issues with data corruption for data taken using PixieSuite2 this throw caused many data files to be unreadable. We have recovered previous functionality and updated the error message accordingly.