### PR TITLE
If the USE_ROOT Flag was turned off, then we couldn't compile ScanLib

### DIFF
--- a/Scan/ScanLib/source/CMakeLists.txt
+++ b/Scan/ScanLib/source/CMakeLists.txt
@@ -1,7 +1,11 @@
 #Set the scan sources that we will make a lib out of
 set(ScanSources ScanInterface.cpp Unpacker.cpp XiaData.cpp ChannelData.cpp
         ChannelEvent.cpp XiaListModeDataMask.cpp XiaListModeDataDecoder.cpp
-        XiaListModeDataEncoder.cpp RootScanner.cpp)
+        XiaListModeDataEncoder.cpp)
+
+if(USE_ROOT)
+    list(APPEND ScanSources RootScanner.cpp)
+endif(USE_ROOT)
 
 #Add the sources to the library
 add_library(ScanObjects OBJECT ${ScanSources})


### PR DESCRIPTION
Fixes compilation error if the USE_ROOT Flag was turned off.