### PR TITLE
Fixing error on the extrapolated maximum

### DIFF
--- a/Scan/utkscan/analyzers/source/WaveformAnalyzer.cpp
+++ b/Scan/utkscan/analyzers/source/WaveformAnalyzer.cpp
@@ -75,7 +75,8 @@ void WaveformAnalyzer::Analyze(Trace &trace, const std::string &type,
         trace.InsertValue("sigmaBaseline", baseline.second);
         trace.InsertValue("maxval", max.second - baseline.first);
         trace.InsertValue("extrapolatedMaxVal",
-                          TraceFunctions::ExtrapolateMaximum(traceNoBaseline, max).first);
+                          TraceFunctions::ExtrapolateMaximum(trace, max)
+                                  .first - baseline.first);
         trace.InsertValue("maxpos", (int)max.first);
         trace.SetBaselineSubtractedTrace(traceNoBaseline);
         trace.SetWaveformRange(waveformRange);


### PR DESCRIPTION
The alteration here broke the performance of the CFD quite a bit. This fixes the original functionality. 