### PR TITLE
Fixes #180 - Old data formats not decoded properly

### DIFF
--- a/Scan/Resources/include/HelperEnumerations.hpp
+++ b/Scan/Resources/include/HelperEnumerations.hpp
@@ -19,8 +19,12 @@ namespace Timing {
 
 namespace DataProcessing {
     ///An enum for the different firmware revisions for the Pixie-16 modules.
-    /// * R29432 is valid from 02/15/2014 and 07/28/2014
-    /// * R30474, R30980, R30981 is valid from 07/28/2014 and 03/08/2016
+    /// * R17562 is valid from 12/15/2010 to 09/26/2011 (this is primarily a
+    /// Rev D firmware, i.e. 100 MS/s)
+    /// * R20466 is valid from 09/26/2011 to 06/11/2013
+    /// * R27361 is valid from 06/11/2013 to 02/15/2014
+    /// * R29432 is valid from 02/15/2014 to 07/28/2014
+    /// * R30474, R30980, R30981 is valid from 07/28/2014 to 03/08/2016
     /// * R29432 is valid from 03/08/2016
     /// * UNKNOWN is used for unspecified firmware revisions.
     ///These dates do not imply that the particular data set being analyzed was
@@ -28,7 +32,7 @@ namespace DataProcessing {
     /// guide the user if they do not know the particular firmware that was used
     /// to obtain their data set.
     enum FIRMWARE {
-        R29432, R30474, R30980, R30981, R34688, UNKNOWN
+        R17562, R20466, R27361, R29432, R30474, R30980, R30981, R34688, UNKNOWN
     };
 
     ///An enumeration that tells how long headers from the XIA List mode data

--- a/Scan/ScanLib/include/XiaListModeDataMask.hpp
+++ b/Scan/ScanLib/include/XiaListModeDataMask.hpp
@@ -25,13 +25,23 @@ public:
         firmware_ = DataProcessing::UNKNOWN;
     }
 
-    ///Constructor accepting a string with the firmware type and the frequency
+    ///Constructor accepting a FIRMWARE enum as an argument
     ///@param[in] firmware : The value we want to set for the firmware
     ///@param[in] freq : The value in MS/s or MHz that we want to assign to the
     /// frequency.
     XiaListModeDataMask(const DataProcessing::FIRMWARE &firmware,
                         const unsigned int &freq) {
         firmware_ = firmware;
+        frequency_ = freq;
+    }
+
+    ///Constructor accepting a string with the firmware type and the frequency
+    ///@param[in] firmware : The value we want to set for the firmware
+    ///@param[in] freq : The value in MS/s or MHz that we want to assign to the
+    /// frequency.
+    XiaListModeDataMask(const std::string &firmware,
+                        const unsigned int &freq) {
+        firmware_ = ConvertStringToFirmware(firmware);
         frequency_ = freq;
     }
 
@@ -123,7 +133,7 @@ public:
 
     ///Getter for the value of the frequency that we're using.
     ///@return The current value of the internal frequency_ variable
-    unsigned int GetFrequency() const { return  frequency_; }
+    unsigned int GetFrequency() const { return frequency_; }
 
     ///Sets the firmware version
     ///@param[in] firmware : The firmware type that we would like to set.
@@ -143,6 +153,12 @@ public:
     /// are working with.
     void SetFrequency(const unsigned int &freq) { frequency_ = freq; }
 
+    ///Converts a string to a firmware version this is used to set the
+    /// firmware using SetFirmware(string) method.
+    ///@param[in] type : A string of the firmware version that we would like.
+    /// It can be prepended with the "R" or not.
+    ///@return The firmware ENUM for the firmware type.
+    DataProcessing::FIRMWARE ConvertStringToFirmware(const std::string &type);
 
 private:
     ///The firmware version that we are using.
@@ -151,8 +167,6 @@ private:
     unsigned int frequency_;
 
     std::string BadMaskErrorMessage(const std::string &func) const;
-
-    DataProcessing::FIRMWARE ConvertStringToFirmware(const std::string &type);
 };
 
 #endif //PIXIESUITE_XIALISTMODEDATAMASK_HPP

--- a/Scan/ScanLib/include/XiaListModeDataMask.hpp
+++ b/Scan/ScanLib/include/XiaListModeDataMask.hpp
@@ -46,49 +46,47 @@ public:
     }
 
     ///Default Destructor
-    ~XiaListModeDataMask() {};
+    ~XiaListModeDataMask() {}
 
     ///Getter for the Mask and Shift of the Channel Number.
     ///@return The pair of the mask and bit shift to use to decode the data.
     std::pair<unsigned int, unsigned int> GetChannelNumberMask() const {
         return std::make_pair(0x0000000F, 0);
-    };
+    }
 
     ///Getter for the Mask and Shift of the Slot Id.
     ///@return The pair of the mask and bit shift to use to decode the data.
     std::pair<unsigned int, unsigned int> GetSlotIdMask() const {
         return std::make_pair(0x000000F0, 4);
-    };
+    }
 
     ///Getter for the Mask and Shift of the Crate ID.
     ///@return The pair of the mask and bit shift to use to decode the data.
     std::pair<unsigned int, unsigned int> GetCrateIdMask() const {
         return std::make_pair(0x00000F00, 8);
-    };
+    }
 
     ///Getter for the Mask and Shift of the Header Length.
     ///@return The pair of the mask and bit shift to use to decode the data.
     std::pair<unsigned int, unsigned int> GetHeaderLengthMask() const {
         return std::make_pair(0x0001F000, 12);
-    };
+    }
 
     ///Getter for the Mask and Shift of the Event Length.
     ///@return The pair of the mask and bit shift to use to decode the data.
-    std::pair<unsigned int, unsigned int> GetEventLengthMask() const {
-        return std::make_pair(0x1FFE0000, 17);
-    };
+    std::pair<unsigned int, unsigned int> GetEventLengthMask() const;
 
     ///Getter for the Mask and Shift of the Finish Code.
     ///@return The pair of the mask and bit shift to use to decode the data.
     std::pair<unsigned int, unsigned int> GetFinishCodeMask() const {
         return std::make_pair(0x80000000, 31);
-    };
+    }
 
     ///Getter for the Mask and Shift of the Event Time High.
     ///@return The pair of the mask and bit shift to use to decode the data.
     std::pair<unsigned int, unsigned int> GetEventTimeHighMask() const {
         return std::make_pair(0x0000FFFF, 0);
-    };
+    }
 
     ///Getter for the Mask and Shift of the Event Time High.
     ///@return The pair of the mask and bit shift to use to decode the data.

--- a/Scan/ScanLib/source/XiaListModeDataMask.cpp
+++ b/Scan/ScanLib/source/XiaListModeDataMask.cpp
@@ -2,8 +2,10 @@
 /// @brief Class that provides the data masks for XIA list mode data
 /// @author S. V. Paulauskas
 /// @date December 29, 2016
+#include <iostream>
 #include <sstream>
-#include <stdexcept>
+
+#include <cstdlib>
 
 #include "XiaListModeDataMask.hpp"
 
@@ -12,16 +14,25 @@ using namespace DataProcessing;
 
 FIRMWARE XiaListModeDataMask::ConvertStringToFirmware(const std::string &type) {
     FIRMWARE firmware = UNKNOWN;
+    unsigned int firmwareNumber = 0;
     stringstream msg;
-    if (type == "R29432")
+
+    //First convert the string into a number
+    if (type.find("R") == 0) {
+        string tmp(type.begin() +1, type.end());
+        firmwareNumber = (unsigned int)atoi(tmp.c_str());
+    } else
+        firmwareNumber = (unsigned int)atoi(type.c_str());
+
+    if(firmwareNumber >= 29432 && firmwareNumber < 30474)
         firmware = R29432;
-    else if (type == "R30474")
+    else if(firmwareNumber >= 30474 && firmwareNumber < 30980)
         firmware = R30474;
-    else if (type == "R30980")
+    else if(firmwareNumber >= 30980 && firmwareNumber < 30981)
         firmware = R30980;
-    else if (type == "R30981")
+    else if(firmwareNumber >= 30981 && firmwareNumber < 34688)
         firmware = R30981;
-    else if (type == "R34688")
+    else if(firmwareNumber == 34688) //compare exactly here since nothing higher
         firmware = R34688;
     else {
         msg << "XiaListModeDataMask::CovnertStringToFirmware : "
@@ -250,7 +261,7 @@ double XiaListModeDataMask::GetCfdSize() const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
         throw invalid_argument(BadMaskErrorMessage
                                        ("GetCfdFractionalTimeMask"));
-    if(frequency_ == 500)
+    if (frequency_ == 500)
         return 8192.;
 
     double val = 0;

--- a/Scan/ScanLib/source/XiaListModeDataMask.cpp
+++ b/Scan/ScanLib/source/XiaListModeDataMask.cpp
@@ -5,8 +5,6 @@
 #include <iostream>
 #include <sstream>
 
-#include <cstdlib>
-
 #include "XiaListModeDataMask.hpp"
 
 using namespace std;
@@ -19,20 +17,27 @@ FIRMWARE XiaListModeDataMask::ConvertStringToFirmware(const std::string &type) {
 
     //First convert the string into a number
     if (type.find("R") == 0) {
-        string tmp(type.begin() +1, type.end());
-        firmwareNumber = (unsigned int)atoi(tmp.c_str());
+        string tmp(type.begin() + 1, type.end());
+        firmwareNumber = (unsigned int) atoi(tmp.c_str());
     } else
-        firmwareNumber = (unsigned int)atoi(type.c_str());
+        firmwareNumber = (unsigned int) atoi(type.c_str());
 
-    if(firmwareNumber >= 29432 && firmwareNumber < 30474)
+    if (firmwareNumber >= 17562 && firmwareNumber < 20466)
+        firmware = R17562;
+    else if (firmwareNumber >= 20466 && firmwareNumber < 27361)
+        firmware = R20466;
+    else if (firmwareNumber >= 27361 && firmwareNumber < 29432)
+        firmware = R27361;
+    else if (firmwareNumber >= 29432 && firmwareNumber < 30474)
         firmware = R29432;
-    else if(firmwareNumber >= 30474 && firmwareNumber < 30980)
+    else if (firmwareNumber >= 30474 && firmwareNumber < 30980)
         firmware = R30474;
-    else if(firmwareNumber >= 30980 && firmwareNumber < 30981)
+    else if (firmwareNumber >= 30980 && firmwareNumber < 30981)
         firmware = R30980;
-    else if(firmwareNumber >= 30981 && firmwareNumber < 34688)
+    else if (firmwareNumber >= 30981 && firmwareNumber < 34688)
         firmware = R30981;
-    else if(firmwareNumber == 34688) //compare exactly here since nothing higher
+    else if (firmwareNumber ==
+             34688) //compare exactly here since nothing higher
         firmware = R34688;
     else {
         msg << "XiaListModeDataMask::CovnertStringToFirmware : "
@@ -52,6 +57,7 @@ XiaListModeDataMask::GetCfdFractionalTimeMask() const {
     unsigned int mask = 0;
     if (frequency_ == 100) {
         switch (firmware_) {
+            case R17562:
             case R29432:
                 mask = 0xFFFF0000;
                 break;
@@ -61,11 +67,15 @@ XiaListModeDataMask::GetCfdFractionalTimeMask() const {
             case R34688:
                 mask = 0x7FFF0000;
                 break;
-            case UNKNOWN:
+            default:
                 break;
         }
     } else if (frequency_ == 250) {
         switch (firmware_) {
+            case R20466:
+                mask = 0xFFFF0000;
+                break;
+            case R27361:
             case R29432:
                 mask = 0x7FFF0000;
                 break;
@@ -75,7 +85,7 @@ XiaListModeDataMask::GetCfdFractionalTimeMask() const {
             case R34688:
                 mask = 0x3FFF0000;
                 break;
-            case UNKNOWN:
+            default:
                 break;
         }
     } else if (frequency_ == 500) {
@@ -87,26 +97,49 @@ XiaListModeDataMask::GetCfdFractionalTimeMask() const {
             case R34688:
                 mask = 0x1FFF0000;
                 break;
-            case UNKNOWN:
+            default:
                 break;
         }
     }
     return make_pair(mask, 16);
 }
 
+std::pair<unsigned int, unsigned int> XiaListModeDataMask::GetEventLengthMask()
+const {
+    if(firmware_ == UNKNOWN)
+        throw invalid_argument(BadMaskErrorMessage("GetEventLengthMask"));
+    unsigned int mask = 0;
+    unsigned int bit = 0;
+    switch(firmware_) {
+        case R17562:
+        case R20466:
+        case R27361:
+            mask = 0x3FFE0000;
+            bit = 17;
+            break;
+        case R29432:
+        case R30474:
+        case R30980:
+        case R30981:
+        case R34688:
+            mask = 0x1FFE0000;
+            bit = 17;
+            break;
+        default:
+            break;
+    }
+    return make_pair(mask, bit);
+}
+
 pair<unsigned int, unsigned int>
 XiaListModeDataMask::GetCfdForcedTriggerBitMask() const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
         throw invalid_argument(BadMaskErrorMessage
-                                       ("GetCfdFractionalTimeMask"));
+                                       ("GetCfdForcedTriggerBitMask"));
     unsigned int mask = 0;
     unsigned int bit = 0;
     if (frequency_ == 100) {
         switch (firmware_) {
-            case R29432:
-                mask = 0;
-                bit = 0;
-                break;
             case R30474:
             case R30980:
             case R30981:
@@ -114,7 +147,7 @@ XiaListModeDataMask::GetCfdForcedTriggerBitMask() const {
                 mask = 0x80000000;
                 bit = 31;
                 break;
-            case UNKNOWN:
+            default:
                 break;
         }
     } else if (frequency_ == 250) {
@@ -126,8 +159,7 @@ XiaListModeDataMask::GetCfdForcedTriggerBitMask() const {
                 mask = 0x80000000;
                 bit = 31;
                 break;
-            case R29432:
-            case UNKNOWN:
+            default:
                 break;
         }
     }
@@ -138,11 +170,12 @@ pair<unsigned int, unsigned int>
 XiaListModeDataMask::GetCfdTriggerSourceMask() const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
         throw invalid_argument(BadMaskErrorMessage
-                                       ("GetCfdFractionalTimeMask"));
+                                       ("GetCfdTriggerSourceMask"));
     unsigned int mask = 0;
     unsigned int bit = 0;
     if (frequency_ == 250) {
         switch (firmware_) {
+            case R27361:
             case R29432:
                 mask = 0x80000000;
                 bit = 31;
@@ -154,7 +187,7 @@ XiaListModeDataMask::GetCfdTriggerSourceMask() const {
                 mask = 0x40000000;
                 bit = 30;
                 break;
-            case UNKNOWN:
+            default:
                 break;
         }
     } else if (frequency_ == 500) {
@@ -167,7 +200,7 @@ XiaListModeDataMask::GetCfdTriggerSourceMask() const {
                 mask = 0xE0000000;
                 bit = 29;
                 break;
-            case UNKNOWN:
+            default:
                 break;
         }
     }
@@ -189,10 +222,13 @@ const {
         case R30981:
             mask = 0x00007FFF;
             break;
+        case R17562:
+        case R20466:
+        case R27361:
         case R34688:
             mask = 0x0000FFFF;
             break;
-        case UNKNOWN:
+        default:
             break;
     }
     return make_pair(mask, 0);
@@ -204,11 +240,17 @@ pair<unsigned int, unsigned int>
 XiaListModeDataMask::GetTraceOutOfRangeFlagMask() const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
         throw invalid_argument(BadMaskErrorMessage
-                                       ("GetCfdFractionalTimeMask"));
+                                       ("GetTraceOutOfRangeFlagMask"));
 
     unsigned int mask = 0;
     unsigned int bit = 0;
     switch (firmware_) {
+        case R17562:
+        case R20466:
+        case R27361:
+            mask = 0x40000000;
+            bit = 30;
+            break;
         case R29432:
         case R30474:
         case R30980:
@@ -220,7 +262,7 @@ XiaListModeDataMask::GetTraceOutOfRangeFlagMask() const {
             mask = 0x80000000;
             bit = 31;
             break;
-        case UNKNOWN:
+        default:
             break;
     }
     return make_pair(mask, bit);
@@ -234,6 +276,9 @@ const {
                                        ("GetCfdFractionalTimeMask"));
     unsigned int mask = 0;
     switch (firmware_) {
+        case R17562:
+        case R20466:
+        case R27361:
         case R29432:
         case R30474:
         case R30980:
@@ -243,7 +288,7 @@ const {
         case R34688:
             mask = 0x7FFF0000;
             break;
-        case UNKNOWN:
+        default:
             break;
     }
     return make_pair(mask, 16);
@@ -267,6 +312,7 @@ double XiaListModeDataMask::GetCfdSize() const {
     double val = 0;
     if (frequency_ == 100) {
         switch (firmware_) {
+            case R17562:
             case R29432:
                 val = 65536;
                 break;
@@ -276,11 +322,15 @@ double XiaListModeDataMask::GetCfdSize() const {
             case R34688:
                 val = 32768;
                 break;
-            case UNKNOWN:
+            default:
                 break;
         }
     } else if (frequency_ == 250) {
         switch (firmware_) {
+            case R20466:
+                val = 65536;
+                break;
+            case R27361:
             case R29432:
                 val = 32768;
                 break;
@@ -290,7 +340,7 @@ double XiaListModeDataMask::GetCfdSize() const {
             case R30474:
                 val = 16384;
                 break;
-            case UNKNOWN:
+            default:
                 break;
         }
     }

--- a/Scan/ScanLib/source/XiaListModeDataMask.cpp
+++ b/Scan/ScanLib/source/XiaListModeDataMask.cpp
@@ -17,7 +17,7 @@ FIRMWARE XiaListModeDataMask::ConvertStringToFirmware(const std::string &type) {
     stringstream msg;
 
     //First convert the string into a number
-    if (type.find("R") == 0) {
+    if (type.find("R") == 0 || type.find("r") == 0) {
         string tmp(type.begin() + 1, type.end());
         firmwareNumber = (unsigned int) atoi(tmp.c_str());
     } else

--- a/Scan/ScanLib/source/XiaListModeDataMask.cpp
+++ b/Scan/ScanLib/source/XiaListModeDataMask.cpp
@@ -4,6 +4,7 @@
 /// @date December 29, 2016
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 
 #include "XiaListModeDataMask.hpp"
 

--- a/Scan/ScanLib/source/XiaListModeDataMask.cpp
+++ b/Scan/ScanLib/source/XiaListModeDataMask.cpp
@@ -123,7 +123,7 @@ const {
         case R30980:
         case R30981:
         case R34688:
-            mask = 0x1FFE0000;
+            mask = 0x7FFE0000;
             bit = 17;
             break;
         default:
@@ -214,7 +214,7 @@ pair<unsigned int, unsigned int> XiaListModeDataMask::GetEventEnergyMask()
 const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
         throw invalid_argument(BadMaskErrorMessage
-                                       ("GetCfdFractionalTimeMask"));
+                                       ("GetEventEnergyMask"));
     unsigned int mask = 0;
     switch (firmware_) {
         case R29432:
@@ -274,7 +274,7 @@ pair<unsigned int, unsigned int> XiaListModeDataMask::GetTraceLengthMask()
 const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
         throw invalid_argument(BadMaskErrorMessage
-                                       ("GetCfdFractionalTimeMask"));
+                                       ("GetTraceLengthMask"));
     unsigned int mask = 0;
     switch (firmware_) {
         case R17562:
@@ -306,7 +306,7 @@ string XiaListModeDataMask::BadMaskErrorMessage(const std::string &func) const {
 double XiaListModeDataMask::GetCfdSize() const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
         throw invalid_argument(BadMaskErrorMessage
-                                       ("GetCfdFractionalTimeMask"));
+                                       ("GetCfdSize"));
     if (frequency_ == 500)
         return 8192.;
 

--- a/Scan/ScanLib/tests/unittest-XiaListModeDataMask.cpp
+++ b/Scan/ScanLib/tests/unittest-XiaListModeDataMask.cpp
@@ -16,6 +16,15 @@ using namespace DataProcessing;
 //Test that we can convert all the firmware names to the right values.
 TEST_FIXTURE(XiaListModeDataMask, TestConvertStringToFirmware) {
     //Check the exact names.
+    CHECK_EQUAL(R17562, ConvertStringToFirmware("R17562"));
+    CHECK_EQUAL(R17562, ConvertStringToFirmware("17562"));
+
+    CHECK_EQUAL(R20466, ConvertStringToFirmware("R20466"));
+    CHECK_EQUAL(R20466, ConvertStringToFirmware("20466"));
+
+    CHECK_EQUAL(R27361, ConvertStringToFirmware("R27361"));
+    CHECK_EQUAL(R27361, ConvertStringToFirmware("27361"));
+    
     CHECK_EQUAL(R29432, ConvertStringToFirmware("R29432"));
     CHECK_EQUAL(R29432, ConvertStringToFirmware("29432"));
 
@@ -27,11 +36,14 @@ TEST_FIXTURE(XiaListModeDataMask, TestConvertStringToFirmware) {
 
     CHECK_EQUAL(R30981, ConvertStringToFirmware("R30981"));
     CHECK_EQUAL(R30981, ConvertStringToFirmware("30981"));
-            
+    
     CHECK_EQUAL(R34688, ConvertStringToFirmware("R34688"));
     CHECK_EQUAL(R34688, ConvertStringToFirmware("34688"));
 
     //Check values in between numbers
+    CHECK_EQUAL(R17562, ConvertStringToFirmware("19000"));
+    CHECK_EQUAL(R20466, ConvertStringToFirmware("23000"));
+    CHECK_EQUAL(R27361, ConvertStringToFirmware("28000"));
     CHECK_EQUAL(R29432, ConvertStringToFirmware("29700"));
     CHECK_EQUAL(R30474, ConvertStringToFirmware("30670"));
     CHECK_EQUAL(R30981, ConvertStringToFirmware("32000"));
@@ -58,9 +70,6 @@ TEST_FIXTURE(XiaListModeDataMask, TestXiaListModeDataMask) {
 
     CHECK_EQUAL((unsigned int) 0x0001F000, GetHeaderLengthMask().first);
     CHECK_EQUAL((unsigned int) 12, GetHeaderLengthMask().second);
-
-    CHECK_EQUAL((unsigned int) 0x1FFE0000, GetEventLengthMask().first);
-    CHECK_EQUAL((unsigned int) 17, GetEventLengthMask().second);
 
     CHECK_EQUAL((unsigned int) 0x80000000, GetFinishCodeMask().first);
     CHECK_EQUAL((unsigned int) 31, GetFinishCodeMask().second);

--- a/Scan/ScanLib/tests/unittest-XiaListModeDataMask.cpp
+++ b/Scan/ScanLib/tests/unittest-XiaListModeDataMask.cpp
@@ -13,6 +13,36 @@
 using namespace std;
 using namespace DataProcessing;
 
+//Test that we can convert all the firmware names to the right values.
+TEST_FIXTURE(XiaListModeDataMask, TestConvertStringToFirmware) {
+    //Check the exact names.
+    CHECK_EQUAL(R29432, ConvertStringToFirmware("R29432"));
+    CHECK_EQUAL(R29432, ConvertStringToFirmware("29432"));
+
+    CHECK_EQUAL(R30474, ConvertStringToFirmware("R30474"));
+    CHECK_EQUAL(R30474, ConvertStringToFirmware("30474"));
+
+    CHECK_EQUAL(R30980, ConvertStringToFirmware("R30980"));
+    CHECK_EQUAL(R30980, ConvertStringToFirmware("30980"));
+
+    CHECK_EQUAL(R30981, ConvertStringToFirmware("R30981"));
+    CHECK_EQUAL(R30981, ConvertStringToFirmware("30981"));
+            
+    CHECK_EQUAL(R34688, ConvertStringToFirmware("R34688"));
+    CHECK_EQUAL(R34688, ConvertStringToFirmware("34688"));
+
+    //Check values in between numbers
+    CHECK_EQUAL(R29432, ConvertStringToFirmware("29700"));
+    CHECK_EQUAL(R30474, ConvertStringToFirmware("30670"));
+    CHECK_EQUAL(R30981, ConvertStringToFirmware("32000"));
+
+    //Two cases for absolute failure of the method is when we have a firmware
+    // version that is higher than the highest known one, and a version
+    // smaller than the smallest known version.
+    CHECK_THROW(ConvertStringToFirmware("45000"), invalid_argument);
+    CHECK_THROW(ConvertStringToFirmware("12"), invalid_argument);
+}
+
 TEST_FIXTURE(XiaListModeDataMask, TestXiaListModeDataMask) {
     //We do not need to test more than on version of these since they are
     // identical across all firmware versions.


### PR DESCRIPTION
This addresses issue #180, all data formats from the first revision of RevF until present should be decoded properly. 

The RevD information is only partial, since it had a significant number of changes from 2010 to 2012. Users may have mixed results decoding these data, especially those data with Virtual Channels. 