### PR TITLE
Resolves #191 - Skeleton failes to compile with HRIBF Libs

### DIFF
--- a/Scan/util/source/Skeleton.cpp
+++ b/Scan/util/source/Skeleton.cpp
@@ -39,7 +39,7 @@ void skeletonUnpacker::ProcessRawEvent(ScanInterface *addr_/*=NULL*/){
 
 #ifdef USE_HRIBF		
 		// If using scanor, output to the generic histogram so we know that something is happening.
-		count1cc_(8000, (current_event->modNum*16+current_event->chanNum), 1);
+		count1cc_(8000, (current_event->GetId()), 1);
 #endif	
 	
 		// Check that this channel event exists.


### PR DESCRIPTION
This was broken when XiaData was overhauled, and was not caught due to the #ifdefs.