### PR TITLE
Fixes #122 - GeneralException from TemplateExpProcessor with no TreeCorrelator node

### DIFF
--- a/Scan/utkscan/CMakeLists.txt
+++ b/Scan/utkscan/CMakeLists.txt
@@ -70,7 +70,8 @@ else(USE_HRIBF)
 endif(NOT USE_HRIBF)
 
 #Add libraries to be linked with utkscan
-target_link_libraries(${SCAN_NAME} ${LIBS} ScanStatic ResourceStatic)
+target_link_libraries(${SCAN_NAME} ${LIBS} ScanStatic ResourceStatic
+        PixieCoreStatic)
 
 #If we have GSL installed link
 if(USE_GSL)

--- a/Scan/utkscan/core/source/DetectorDriver.cpp
+++ b/Scan/utkscan/core/source/DetectorDriver.cpp
@@ -20,6 +20,7 @@
 #include "DammPlotIds.hpp"
 #include "DetectorDriver.hpp"
 #include "DetectorLibrary.hpp"
+#include "Display.h"
 #include "Exceptions.hpp"
 #include "HighResTimingData.hpp"
 #include "RandomPool.hpp"
@@ -90,7 +91,7 @@ DetectorDriver::DetectorDriver() : histo(OFFSET, RANGE, "DetectorDriver") {
         m.fail();
         cout << "Exception caught at DetectorDriver::DetectorDriver" << endl;
         cout << "\t" << e.what() << endl;
-        exit(EXIT_FAILURE);
+        throw;
     } catch (GeneralWarning &w) {
         cout << "Warning found at DetectorDriver::DetectorDriver" << endl;
         cout << "\t" << w.what() << endl;
@@ -375,12 +376,15 @@ void DetectorDriver::ProcessEvent(RawEvent& rawev) {
     } catch (GeneralException &e) {
         /// Any exception in activation of basic places, PreProcess and Process
         /// will be intercepted here
-        cout << "Exception caught at DetectorDriver::ProcessEvent" << endl;
-        cout << "\t" << e.what() << endl;
-        exit(EXIT_FAILURE);
+        cout << endl
+             << Display::ErrorStr("Exception caught at DetectorDriver::ProcessEvent")
+             << endl;
+        throw;
     } catch (GeneralWarning &w) {
-        cout << "Warning caught at DetectorDriver::ProcessEvent" << endl;
-        cout << "\t" << w.what() << endl;
+        cout << Display::WarningStr("Warning caught at "
+                                            "DetectorDriver::ProcessEvent")
+             << endl;
+        cout << "\t" << Display::WarningStr(w.what()) << endl;
     }
 }
 
@@ -446,9 +450,10 @@ void DetectorDriver::DeclarePlots() {
             (*it)->DeclarePlots();
         }
     } catch (exception &e) {
-        cout << "Exception caught at DetectorDriver::DeclarePlots" << endl;
-        cout << "\t" << e.what() << endl;
-        exit(EXIT_FAILURE);
+        cout << Display::ErrorStr("Exception caught at "
+                                          "DetectorDriver::DeclarePlots")
+             << endl;
+        throw;
     }
 }
 

--- a/Scan/utkscan/core/source/UtkUnpacker.cpp
+++ b/Scan/utkscan/core/source/UtkUnpacker.cpp
@@ -112,19 +112,24 @@ void UtkUnpacker::ProcessRawEvent(ScanInterface *addr_/*=NULL*/) {
         ///@TODO Add back in the processing for the dtime.
     }//for(deque<PixieData*>::iterator
 
-    driver->ProcessEvent(rawev);
-    rawev.Zero(usedDetectors);
-    usedDetectors.clear();
+    try {
+        driver->ProcessEvent(rawev);
+        rawev.Zero(usedDetectors);
+        usedDetectors.clear();
 
-    // If a place has a resetable type then reset it.
-    for (map<string, Place *>::iterator it =
-            TreeCorrelator::get()->places_.begin();
-         it != TreeCorrelator::get()->places_.end(); ++it)
-        if ((*it).second->resetable())
-            (*it).second->reset();
+        // If a place has a resetable type then reset it.
+        for (map<string, Place *>::iterator it =
+                TreeCorrelator::get()->places_.begin();
+             it != TreeCorrelator::get()->places_.end(); ++it)
+            if ((*it).second->resetable())
+                (*it).second->reset();
+    } catch (exception &ex) {
+        throw;
+    }
 
     eventCounter++;
     lastTimeOfPreviousEvent = GetRealStopTime();
+
 }
 
 /// This method plots information about the running time of the program, the

--- a/Scan/utkscan/core/source/utkscan.cpp
+++ b/Scan/utkscan/core/source/utkscan.cpp
@@ -1,6 +1,8 @@
+#include <exception>
 #include <iostream>
 
 // Local files
+#include "Display.h"
 #include "UtkScanInterface.hpp"
 #include "UtkUnpacker.hpp"
 
@@ -27,7 +29,12 @@ int main(int argc, char *argv[]){
 
     // Run the main loop.
     cout << "utkscan.cpp : Performing Execute method" << endl;
-    int retval = scanner.Execute();
+    int retval = 0;
+    try {
+        retval = scanner.Execute();
+    }catch(std::exception &ex) {
+        cout << Display::ErrorStr(ex.what()) << endl;
+    }
     
     //Cleanup the scanning
     cout << "utkscan.cpp : Closing things out" << endl;


### PR DESCRIPTION
I have replaced the exits that occur during the exceptions with throw. This will throw the errorup until it reaches main, where we handle exiting cleanly by returning. This fixes the issue where the terminal would get corrupted.