### PR TITLE
Fixes #120 - Running utkscan with no output specified creates hard to delete files

### DIFF
--- a/Scan/ScanLib/source/ScanInterface.cpp
+++ b/Scan/ScanLib/source/ScanInterface.cpp
@@ -386,6 +386,10 @@ ScanInterface::ScanInterface(Unpacker *core_/*=NULL*/){
 	scan_init = false;
 	file_open = false;
 
+    //Initialize the setup and output file names
+    output_filename = "";
+    setup_filename = "";
+
 	kill_all = false;
 	run_ctrl_exit = false;
 

--- a/Scan/utkscan/core/source/UtkScanInterface.cpp
+++ b/Scan/utkscan/core/source/UtkScanInterface.cpp
@@ -1,4 +1,7 @@
+#include <stdexcept>
+
 #include "DetectorDriver.hpp"
+#include "Display.h"
 #include "UtkScanInterface.hpp"
 #include "UtkUnpacker.hpp"
 
@@ -71,7 +74,11 @@ bool UtkScanInterface::Initialize(std::string prefix_) {
     //This should be cleaned up!!
 #ifndef USE_HRIBF
     try {
-        // Read in the name of the his file.
+        if(GetOutputFilename() == "") {
+            throw std::invalid_argument("The output file name was not "
+                                                "provided.");
+        }
+
         output_his = new OutputHisFile(GetOutputFilename().c_str());
         output_his->SetDebugMode(false);
 
@@ -91,10 +98,9 @@ bool UtkScanInterface::Initialize(std::string prefix_) {
         DetectorDriver::get()->DeclarePlots();
         output_his->Finalize();
     } catch (std::exception &e) {
-        // Any exceptions will be intercepted here
-        std::cout << prefix_ << "Exception caught at Initialize:" << std::endl;
-        std::cout << prefix_ << e.what() << std::endl;
-        exit(EXIT_FAILURE);
+        std::cout << Display::ErrorStr(prefix_ + "Exception caught at UtkScanInterface::Initialize")
+                  << std::endl;
+        throw;
     }
 #endif
     return (init_ = true);


### PR DESCRIPTION
We now check during initialization that the output file name has been provided to the scan code. These values are initialized to an empty string in the ScanInterface to facilitate this check.