### PR TITLE
Fixed incorrect DATA buffer size due to spill footer

### DIFF
--- a/Core/source/hribf_buffers.cpp
+++ b/Core/source/hribf_buffers.cpp
@@ -704,9 +704,10 @@ bool DATA_buffer::Write(std::ofstream *file_, char *data_, unsigned int nWords_,
 	if(buff_pos > LDF_DATA_LENGTH)
 		std::cout << "WARNING: Final ldf buffer overfilled by " << buff_pos - LDF_DATA_LENGTH << " words!\n";
 
-	// Write the spill footer.
-	if(buff_pos + 6 > LDF_DATA_LENGTH){
+	// Check if we can fit the spill footer into the current buffer.
+	if(buff_pos + 6 > LDF_DATA_LENGTH){ // Close the current buffer and open a new one.
 		buffs_written++;
+		Close(file_);
 		open_(file_);
 	}
 	


### PR DESCRIPTION
Previously, the ldf DATA buffer writer incorrectly
handled occurances where the spill footer could not
fit in the current buffer. This was causing certain
DATA buffers to have a number of words less than
8194 and, in turn, causing the ldf reader to get
out of position.