### PR TITLE
Resolves #72 - Modify set2ascii to provide correct tau values

### DIFF
--- a/Acquisition/PxiDump/source/set2root.cpp
+++ b/Acquisition/PxiDump/source/set2root.cpp
@@ -17,6 +17,7 @@
 #include "TFile.h"
 #endif
 
+#include "HelperFunctions.hpp"
 #include "set2root.hpp"
 
 #define FILTER_CLOCK 8E-3 // Filter clock (in us)
@@ -68,7 +69,12 @@ std::string parameter::print(){
 			stream << name << "[";
 			if(count < 10)
 				stream << "0";
-			stream << count << "]" << "\t" << (*iter) << "\n";
+			stream << count << "]" << "\t";
+			if(name != "PreampTau")
+				stream << (*iter);
+			else
+				stream << IeeeStandards::IeeeFloatingToDecimal((*iter));
+			stream << "\n";
 			count++;
 		}
 	}

--- a/Resources/include/HelperFunctions.hpp
+++ b/Resources/include/HelperFunctions.hpp
@@ -432,4 +432,31 @@ namespace TraceFunctions {
 
     }
 }
+
+namespace IeeeStandards {
+    ///This function converts an IEEE Floating Point number into a standard
+    /// decimal format. This function was stolen almost verbatim from
+    /// utilities.c provided by XIA. This data format is used by XIA to store
+    /// both TAU and the Baseline. Magic numbers abound since we're
+    /// literally following a prescription on how this information is
+    /// stored.
+    ///https://en.wikipedia.org/wiki/IEEE_floating_point#IEEE_754-2008
+    ///@param[in] IeeeFloatingNumber : The IEEE Floating point number that we
+    /// want to convert to decimal
+    ///@return The decimal number that's been decoded from the input.
+    inline double IeeeFloatingToDecimal(
+            const unsigned int &IeeeFloatingNumber) {
+        double result;
+        short signbit = (short)(IeeeFloatingNumber >> 31);
+        short exponent = (short)((IeeeFloatingNumber & 0x7F800000) >> 23) - 127;
+        double mantissa =
+                1.0 + (double)(IeeeFloatingNumber & 0x7FFFFF) / pow(2.0, 23.0);
+        if(signbit == 0)
+            result = mantissa * pow(2.0, (double)exponent);
+        else
+            result = - mantissa * pow(2.0, (double)exponent);
+        return result;
+    }
+}
+
 #endif //PIXIESUITE_HELPERFUNCTIONS_HPP

--- a/Resources/tests/unittest-HelperFunctions.cpp
+++ b/Resources/tests/unittest-HelperFunctions.cpp
@@ -178,6 +178,12 @@ TEST(TestCalculateTailRatio) {
     CHECK_CLOSE(tail_ratio, result, 1e-6);
 }
 
+TEST(TestIeeeFloatingToDecimal) {
+    unsigned int input = 1164725159;
+    double expected = 3780.7283;
+    CHECK_CLOSE(expected, IeeeStandards::IeeeFloatingToDecimal(input), 1e-4);
+}
+
 int main(int argv, char *argc[]) {
     return (UnitTest::RunAllTests());
 }


### PR DESCRIPTION
We added a method to convert from IEEE Floating point standard number to human readable decimal number. Added a unit test for this function, and fixed the output in set2ascii. We did this so that we could use these number in calculations, and verification of settings.