### PR TITLE
Fixes #207 - Missing <stdexcept> header include

### DIFF
--- a/Acquisition/Interface/source/PixieInterface.cpp
+++ b/Acquisition/Interface/source/PixieInterface.cpp
@@ -2,6 +2,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 
 #include <cstdlib>
 #include <cstring>

--- a/Acquisition/Poll/source/poll2_core.cpp
+++ b/Acquisition/Poll/source/poll2_core.cpp
@@ -19,7 +19,9 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
+#include <stdexcept>
 #include <string>
+
 #include <string.h>
 #include <stdlib.h>
 #include <sstream>


### PR DESCRIPTION
These missing headers caused compilation issues on some computers. Fixes #207.