### PR TITLE
Resolves #82 - Linking error USE_GSL=OFF

### DIFF
--- a/Analysis/CMakeLists.txt
+++ b/Analysis/CMakeLists.txt
@@ -1,5 +1,6 @@
 option(USE_HRIBF "Use HRIBF library for scan base." OFF)
-option(USE_GSL "Use GSL for Pulse Fitting" OFF)
+CMAKE_DEPENDENT_OPTION(USE_GSL "Compile with GSL" ON "BUILD_UTKSCAN" OFF)
+mark_as_advanced(USE_GSL)
 
 #Check if GSL is installed
 if(USE_GSL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
 endif(CMAKE_BUILD_TYPE MATCHES "Debug")
 
 #------------------------------------------------------------------------------
+#We are going to include this additional module here since it could be useful
+#when setting all of the following options.
+include(CMakeDependentOption)
 
 #Install options
 option(BUILD_ACQ "Build and install Acquisition software" ON)


### PR DESCRIPTION
Adding in new CMake module to allow for dependent options.
Including this module allows us to have the USE_GSL option depend on the BUILD_UTKSCAN option. We no longer have the issue where the two are decoupled and this resolves the error that we previously had.