### PR TITLE
Adding additional check on GSL in the utkscan CMakeLists

### DIFF
--- a/Analysis/Utkscan/CMakeLists.txt
+++ b/Analysis/Utkscan/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (NOT USE_GSL)
+    message(FATAL_ERROR "GSL is required to build Utkscan!")
+endif (NOT USE_GSL)
+
 #CMake file for UTKScan.
 option(UTKSCAN_GAMMA_GATES "Gamma-Gamma gates in GeProcessor" OFF)
 option(UTKSCAN_ONLINE "Options for online scans" OFF)


### PR DESCRIPTION
The GSL flag can be disabled by an advanced user. This would not throw an error until the linking stage. The new addition will catch this error much sooner and provide the user with some information about what happened.