### PR TITLE
Add clarification to the 2 functions that return baseline information

### DIFF
--- a/Analysis/ScanLibraries/include/XiaData.hpp
+++ b/Analysis/ScanLibraries/include/XiaData.hpp
@@ -89,9 +89,10 @@ public:
     ///@return True if this channel was generated on the module
     bool IsVirtualChannel() const { return isVirtualChannel_; }
 
-    ///@return The baseline as it was calculated on the module.
-    ///The calculation was done using a filter.
-    /// This requires that ESUMS parameter be enabled on the modules during acquisition.
+    ///@return The baseline as calculated on-board the Pixie-16 modules using
+    /// the energy filter. This parameter is only set if the data set
+    /// contains the Energy Sums in the list mode data. This baseline cannot
+    /// be used in conjunction with trace information.
     double GetBaseline() const { return baseline_; }
 
     ///@return The energy that was calculated on the module

--- a/Analysis/ScanLibraries/include/XiaData.hpp
+++ b/Analysis/ScanLibraries/include/XiaData.hpp
@@ -89,7 +89,9 @@ public:
     ///@return True if this channel was generated on the module
     bool IsVirtualChannel() const { return isVirtualChannel_; }
 
-    ///@return The baseline as it was calculated on the module
+    ///@return The baseline as it was calculated on the module.
+    ///The calculation was done using a filter.
+    /// This requires that ESUMS parameter be enabled on the modules during acquisition.
     double GetBaseline() const { return baseline_; }
 
     ///@return The energy that was calculated on the module

--- a/Analysis/Utkscan/core/include/HighResTimingData.hpp
+++ b/Analysis/Utkscan/core/include/HighResTimingData.hpp
@@ -42,13 +42,17 @@ public:
         return(false);
     }
 
-    /** \return The current value of aveBaseline_ .
-      This value is calculated during the fitting procedure as a straight sum, from the trace. */
+    /**This baseline value is calculated from the trace by averaging the
+     * points preceding the waveform
+        \return The current value of aveBaseline_ .*/
     double GetAveBaseline() const { return GetTrace().GetBaselineInfo().first; }
+
     /** \return The current value of discrimination_ */
     double GetDiscrimination() const { return GetTrace().GetTailRatio(); }
+
     /** \return The current value of maxpos_ */
     double GetMaximumPosition() const { return GetTrace().GetMaxInfo().first; }
+
     /** \return The current value of maxval_ */
     double GetMaximumValue() const { return GetTrace().GetMaxInfo().second; }
 

--- a/Analysis/Utkscan/core/include/HighResTimingData.hpp
+++ b/Analysis/Utkscan/core/include/HighResTimingData.hpp
@@ -42,7 +42,8 @@ public:
         return(false);
     }
 
-    /** \return The current value of aveBaseline_ */
+    /** \return The current value of aveBaseline_ .
+      This value is calculated during the fitting procedure as a straight sum, from the trace. */
     double GetAveBaseline() const { return GetTrace().GetBaselineInfo().first; }
     /** \return The current value of discrimination_ */
     double GetDiscrimination() const { return GetTrace().GetTailRatio(); }


### PR DESCRIPTION
This should fix issue #230.

XiaData::GetBaseline() and HighResTimingData::GetAvgBaseline() are the 2 functions