### PR TITLE
Resolves Issue #238 - Update timing analysis for better error handling

### DIFF
--- a/Analysis/Resources/include/GslFitter.hpp
+++ b/Analysis/Resources/include/GslFitter.hpp
@@ -23,15 +23,6 @@ public:
     ///Default Destructor
     ~GslFitter() {}
 
-    /// @return the amplitude from the GSL fit
-    double GetAmplitude(void) { return amp_; }
-
-    /// @return the chi^2 from the GSL fit
-    double GetChiSq(void) { return chi_ * chi_; }
-
-    /// @return the chi^2dof from the GSL fit
-    double GetChiSqPerDof(void) { return GetChiSq() / dof_; }
-
     ///The ever important phase calculation
     /// @param[in] data The baseline subtracted data for the fitting
     /// @param[in] pars The parameters for the fit
@@ -41,10 +32,6 @@ public:
                           const std::pair<double, double> &pars,
                           const std::pair<unsigned int, double> &max,
                           const std::pair<double, double> baseline);
-
-    ///Sets the isFastSiPm_ flag
-    ///@param[in] a : The value that we are going to set
-    void SetIsFastSiPm(const bool &a) { isFastSiPm_ = a; }
 
     /// @brief Structure necessary for the GSL fitting routines
     struct FitData {
@@ -56,12 +43,8 @@ public:
         double qdc;//!< the QDC for the fit
     };
 private:
-    bool isFastSiPm_;
-
     double amp_;
     double chi_;
     double dof_;
 };
-
-
 #endif //PIXIESUITE_GSLFITTER_HPP

--- a/Analysis/Resources/include/TimingDriver.hpp
+++ b/Analysis/Resources/include/TimingDriver.hpp
@@ -58,10 +58,25 @@ public:
         return 0.0;
     }
 
+    /// @return the amplitude from fits
+    virtual double GetAmplitude(void) { return 0.0; }
+
+    /// @return the chi^2 from the GSL fit
+    virtual double GetChiSq(void) { return 0.0; }
+
+    /// @return the chi^2dof from the GSL fit
+    virtual double GetChiSqPerDof(void) { return 0.0; }
+
+    ///Sets the isFastSiPm_ flag
+    ///@param[in] a : The value that we are going to set
+    void SetIsFastSiPm(const bool &a) { isFastSiPm_ = a; }
+
     /// Sets the QDC that we want to set
     /// \param[in] a the qdc of the waveform for the fit
     void SetQdc(const double &a) { qdc_ = a; }
 protected:
+    ///! True if we want to analyze signals from SiPM fast outputs
+    bool isFastSiPm_;
     std::vector<double> results_; //!< Vector containing results
     double qdc_;//!< qdc of the waveform being fitted
 };

--- a/Analysis/ScanLibraries/include/Trace.hpp
+++ b/Analysis/ScanLibraries/include/Trace.hpp
@@ -113,6 +113,9 @@ public:
                                          begin() + waveformRange_.second);
     }
 
+    ///@return True if we were able to successfully analyze the trace.
+    bool HasValidAnalysis() const { return hasValidAnalysis_; }
+
     ///@return True if the trace was saturated
     bool IsSaturated() { return isSaturated_; }
 
@@ -145,6 +148,11 @@ public:
         filteredEnergies_ = a;
     }
 
+    ///Sets the value of hasValidAnalysis_
+    ///@param[in] a : True if we were able to successfully analyze this trace
+    /// for information about the maximum, baseline, phase, etc.
+    void SetHasValidAnalysis(const bool &a) { hasValidAnalysis_ = a; }
+
     ///Sets the isSaturated_ private variable.
     ///@param[in] a : Sets to true if the trace was flagged as saturated by
     /// the electronics.
@@ -156,7 +164,7 @@ public:
     /// baseline subtracted value.
     void SetMax(const std::pair<unsigned int, double> &a) { max_ = a; }
 
-    ///Sets the sub-sampling phase of the trace.
+    ///Sets the sub-sampling phase of the trace in units of samples.
     ///@param[in] a : The value of the phase that we want to set. This
     /// comes from a fit or CFD analysis of the trace.
     void SetPhase(const double &a) { phase_ = a; }
@@ -201,6 +209,7 @@ public:
 
 private:
     bool isSaturated_; ///< True if the trace was flagged as saturated.
+    bool hasValidAnalysis_;///< True if the analysis of the trace was successful
 
     double phase_; ///< The sub-sampling phase of the trace.
     double qdc_; ///< The qdc that was calculated from the waveform.

--- a/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
@@ -39,8 +39,8 @@ FittingAnalyzer::FittingAnalyzer(const std::string &s) {
 #endif
     else {
         stringstream ss;
-        ss << "FittingAnalyzer::Analyze - The driver type \"" << s << "\" was "
-                "unknown. Please choose a valid driver.";
+        ss << "FittingAnalyzer::FittingAnalyzer - The driver type \"" << s
+           << "\" was unknown. Please choose a valid driver.";
         throw GeneralException(ss.str());
     }
 }

--- a/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
@@ -15,13 +15,16 @@
  */
 #include <algorithm>
 #include <iostream>
+#include <sstream>
 #include <vector>
 
 #include "FittingAnalyzer.hpp"
 #include "GslFitter.hpp"
 
 #ifdef USE_ROOT
+
 #include "RootFitter.hpp"
+
 #endif
 
 using namespace std;
@@ -34,8 +37,12 @@ FittingAnalyzer::FittingAnalyzer(const std::string &s) {
     else if (s == "ROOT" || s == "root")
         driver_ = new RootFitter();
 #endif
-    else
-        driver_ = NULL;
+    else {
+        stringstream ss;
+        ss << "FittingAnalyzer::Analyze - The driver type \"" << s << "\" was "
+                "unknown. Please choose a valid driver.";
+        throw GeneralException(ss.str());
+    }
 }
 
 FittingAnalyzer::~FittingAnalyzer() {
@@ -52,7 +59,8 @@ void FittingAnalyzer::Analyze(Trace &trace, const std::string &detType,
                                        "was not provided. This is a fatal "
                                        "error.");
 
-    if (trace.IsSaturated() || trace.empty() || trace.GetWaveform().empty()) {
+    if (trace.IsSaturated() || trace.empty() || !trace.HasValidAnalysis()) {
+        trace.SetPhase(0.0);
         EndAnalyze();
         return;
     }

--- a/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
@@ -22,9 +22,7 @@
 #include "GslFitter.hpp"
 
 #ifdef USE_ROOT
-
 #include "RootFitter.hpp"
-
 #endif
 
 using namespace std;
@@ -53,11 +51,6 @@ void FittingAnalyzer::Analyze(Trace &trace, const std::string &detType,
                               const std::string &detSubtype,
                               const std::map<std::string, int> &tagMap) {
     TraceAnalyzer::Analyze(trace, detType, detSubtype, tagMap);
-
-    if (!driver_)
-        throw invalid_argument("FittingAnalyzer::Analyze : A fitting driver "
-                                       "was not provided. This is a fatal "
-                                       "error.");
 
     if (trace.IsSaturated() || trace.empty() || !trace.HasValidAnalysis()) {
         trace.SetPhase(0.0);
@@ -91,6 +84,8 @@ void FittingAnalyzer::Analyze(Trace &trace, const std::string &detType,
         pars = globals->GetFitPars(detType + ":" + detSubtype + ":timing");
 
     driver_->SetQdc(trace.GetQdc());
+    if(isFastSiPm)
+        driver_->SetIsFastSiPm(isFastSiPm);
     double phase = driver_->CalculatePhase(trace.GetWaveform(), pars,
                                            trace.GetMaxInfo(),
                                            trace.GetBaselineInfo());

--- a/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
@@ -76,6 +76,19 @@ void WaveformAnalyzer::Analyze(Trace &trace, const std::string &type,
                 TraceFunctions::CalculateBaseline(
                         trace, make_pair(0, max.first - range.first));
 
+        //For well behaved traces the standard deviation of the baseline
+        // shouldn't ever be more than 1-3 ADC units. However, for traces
+        // that are not captured properly, we can get really crazy values
+        // here the SiPM often saw values as high as 20. We will put in a
+        // hard limit of 50 as a cutoff since anything with a standard
+        // deviation of this high will never be something we want to analyze.
+        static const double extremeBaselineVariation = 50;
+        if(baseline.second >= extremeBaselineVariation) {
+            trace.SetHasValidAnalysis(false);
+            EndAnalyze();
+            return;
+        }
+
         //Subtract the baseline from the maximum value.
         max.second -= baseline.first;
 

--- a/Analysis/Utkscan/core/include/HighResTimingData.hpp
+++ b/Analysis/Utkscan/core/include/HighResTimingData.hpp
@@ -32,13 +32,11 @@ public:
                 pow((z0/tof)/Physical::speedOfLightInCmPerNs, 2)));
     }
 
-    /** \return True if maxval,tqdc and sigmaBaseline were not NAN */
+    ///@return True if the trace was successfully analyzed and we managed to
+    /// find a phase.
     bool GetIsValid() const {
-        if(!std::isnan(GetTrace().GetMaxInfo().second) &&
-           !std::isnan(GetTrace().GetQdc()) &&
-           !std::isnan(GetTrace().GetBaselineInfo().first) ) {
+        if(GetTrace().HasValidAnalysis() && GetTrace().GetPhase() != 0.0)
             return(true);
-        }
         return(false);
     }
 


### PR DESCRIPTION
Resolves issue #238. I added some additional error checking to the FittingAnalyzer so that it verifies sooner that it didn't get a valid option for the driver. I have moved some of the methods from the GslFitter to the TimingDriver so that they can be used by other derived classes. This resolves an issue seen by users where the flags for fitting the SiPM Fast signals were not being handled properly. 