### PR TITLE
Resolves #247 - Bad logic in the GlobalsXmlParser::ParseRejectNode

### DIFF
--- a/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
@@ -220,7 +220,7 @@ vector<pair<unsigned int, unsigned int> > GlobalsXmlParser::ParseRejectNode(
         int end = time.attribute("end").as_int(0);
 
         std::stringstream ss;
-        if (start == 0 || end == 0 || start > end) {
+        if ( (start == 0 && end == 0) || start > end) {
             ss << "Globals: incomplete or wrong rejection region "
                << "declaration: " << start << ", " << end;
             throw invalid_argument(ss.str());


### PR DESCRIPTION
The previous logic was not allowing users to parse rejection regions with a start of 0. 