### PR TITLE
Resolves #266 (non-helpful error with a missing TraceDelay node)

### DIFF
--- a/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
@@ -271,7 +271,8 @@ void GlobalsXmlParser::ParseTraceNode(const pugi::xml_node &node, Globals *globa
         globals->SetTraceDelay(
                 node.child("TraceDelay").attribute("value").as_uint());
     } else
-        throw CriticalNodeMessage(node.child("TraceDelay").name());
+        throw invalid_argument(CriticalNodeMessage(node.child("TraceDelay")
+                                                           .name()));
 
     sstream_ << "Trace Delay : " << globals->GetTraceDelayInNs() << " ns";
     messenger_.detail(sstream_.str());

--- a/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
@@ -271,8 +271,7 @@ void GlobalsXmlParser::ParseTraceNode(const pugi::xml_node &node, Globals *globa
         globals->SetTraceDelay(
                 node.child("TraceDelay").attribute("value").as_uint());
     } else
-        throw invalid_argument(CriticalNodeMessage(node.child("TraceDelay")
-                                                           .name()));
+        throw invalid_argument(CriticalNodeMessage("TraceDelay"));
 
     sstream_ << "Trace Delay : " << globals->GetTraceDelayInNs() << " ns";
     messenger_.detail(sstream_.str());


### PR DESCRIPTION
Adds the missing  invalid_argument call, and resolves #266 