### PR TITLE
Resolves: Issue251 with type:subtype Trace Delays

### DIFF
--- a/Analysis/Utkscan/analyzers/include/WaveformAnalyzer.hpp
+++ b/Analysis/Utkscan/analyzers/include/WaveformAnalyzer.hpp
@@ -33,6 +33,7 @@ public:
 
 private:
     Messenger *messenger_;//!< A pointer for the messenger class
+    std::string TDdet_; //!<string of type:subtype for the tracedelay function
 };
 
 #endif // __WAVEFORMANALYZER_HPP_

--- a/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
@@ -44,10 +44,10 @@ void WaveformAnalyzer::Analyze(Trace &trace, const std::string &type,
 
     try {
         //First we calculate the position of the maximum.
+        TDdet_ = type + ":" + subtype;
         pair<unsigned int, double> max =
-                TraceFunctions::FindMaximum(trace, globals->GetTraceDelayInNs() /
-                                                   (globals->GetAdcClockInSeconds() *
-                                                    1.e9));
+                TraceFunctions::FindMaximum(trace, globals->GetTraceDelayInNs
+                        (TDdet_) / (globals->GetAdcClockInSeconds() * 1.e9));
 
         //Next we calculate the baseline and its standard deviation
         pair<double, double> baseline =

--- a/Analysis/Utkscan/core/include/Globals.hpp
+++ b/Analysis/Utkscan/core/include/Globals.hpp
@@ -268,8 +268,8 @@ public:
 
     ///Sets the trace delay that will be used to find the waveform.
     ///@param[in] a : Sets the trace delay in units of ns.
-    void SetTraceDelay(const std::string &str , const unsigned int
-    &a) { traceDelay_=std::map<&str,&a>; }
+    void SetTraceDelay(const std::map<std::string , unsigned int > &a) {
+        traceDelay_ = a; }
 
     ///Sets the map containing all of the filter parameters that we are going
     /// to need.

--- a/Analysis/Utkscan/core/include/Globals.hpp
+++ b/Analysis/Utkscan/core/include/Globals.hpp
@@ -125,8 +125,15 @@ public:
     ///@return the frequency of the system clock in Hz
     double GetSystemClockFreqInHz() const { return sysClockFreqInHz_; }
 
-    ///@return the trace delay of the traces in ns 
-    double GetTraceDelayInNs() const { return traceDelay_; }
+    ///@param[in] str : A string of the form "type:subtype" used to find
+    /// parameters
+    ///@return the trace delay of the traces in ns
+    unsigned int GetTraceDelayInNs(const std::string &str = "global")
+    const {
+        if (traceDelay_.find(str) != traceDelay_.end())
+            return (traceDelay_.find(str)->second);
+        return (traceDelay_.find("global")->second);
+    }
 
     ///@return the length of the big VANDLE bars in ns
     double GetVandleBigLengthInNs() const {
@@ -261,7 +268,8 @@ public:
 
     ///Sets the trace delay that will be used to find the waveform.
     ///@param[in] a : Sets the trace delay in units of ns.
-    void SetTraceDelay(const unsigned int &a) { traceDelay_ = a; }
+    void SetTraceDelay(const std::string &str , const unsigned int
+    &a) { traceDelay_=std::map<&str,&a>; }
 
     ///Sets the map containing all of the filter parameters that we are going
     /// to need.
@@ -329,7 +337,8 @@ private:
     double siPmSigmaBaselineThresh_;//!< threshold on fitting for Std dev. of the baseline for SiPMTs
     double sysClockFreqInHz_; //!< frequency of the system clock
     std::vector<std::pair<unsigned int, unsigned int> > reject_; ///< Rejection regions
-    unsigned int traceDelay_;//!< the trace delay in ns
+    std::map<std::string, unsigned int> traceDelay_;//!< the trace delay in
+//!< ns for a given type:subtype (or global delay)
     std::map<std::string, std::pair<TrapFilterParameters, TrapFilterParameters> > trapFiltPars_; //!<Map containing all of the trapezoidal filter parameters for a given type:subtype
     double vandleBigSpeedOfLight_;//!< speed of light in big VANDLE bars in cm/ns
     double vandleMediumSpeedOfLight_;//!< speed of light in medium VANDLE bars in cm/ns

--- a/Analysis/Utkscan/core/source/Globals.cpp
+++ b/Analysis/Utkscan/core/source/Globals.cpp
@@ -56,7 +56,7 @@ void Globals::InitializeMemberVariables() {
     sysClockFreqInHz_ = sysconf(_SC_CLK_TCK);
     hasRawHistogramsDefined_ = true;
     outputFilename_ = outputPath_ = revision_ = "";
-    eventLengthInTicks_ = traceDelay_ = discriminationStart_ = 0;
+    eventLengthInTicks_ = discriminationStart_ = 0;
     qdcCompression_ = 1.0;
     adcClockInSeconds_ = clockInSeconds_ = eventLengthInSeconds_ =
     filterClockInSeconds_ = sigmaBaselineThresh_ =

--- a/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
@@ -292,6 +292,7 @@ void GlobalsXmlParser::ParseTraceNode(const pugi::xml_node &node, Globals *globa
     } else
         throw invalid_argument(CriticalNodeMessage("TraceDelay"));
 
+    sstream_.str("");
     if (!node.child("QdcCompression").empty())
         globals->SetQdcCompression(
                 node.child("QdcCompression").attribute("value").as_double());

--- a/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
@@ -272,27 +272,40 @@ void GlobalsXmlParser::ParseTraceNode(const pugi::xml_node &node, Globals *globa
 
     if (!node.child("TraceDelay").empty()) {
         std::map<std::string, unsigned int> delays;
-        for (pugi::xml_node_iterator tdit = node.child("TraceDelay").begin();
-             tdit != node.child("TraceDelay").end(); ++tdit) {
-            std::string name = tdit->name();
-            unsigned int tdelay = tdit->attribute("value").as_uint();
-            delays.insert(make_pair(name, tdelay));
-        }
-        globals->SetTraceDelay(delays);
+        if (!node.child("TraceDelay").attribute("value").empty()) {
+            delays.insert(make_pair("global", node.child("TraceDelay").attribute("value").as_uint()));
+            globals->SetTraceDelay(delays);
 
-        sstream_ << "Trace Delays:";
-        messenger_.detail(sstream_.str());
-        for (std::map<std::string, unsigned int>::const_iterator tdloop =
-                delays.begin(); tdloop != delays.end(); tdloop++) {
+            sstream_ << "Trace Delay : " << globals->GetTraceDelayInNs();
+            messenger_.detail(sstream_.str());
             sstream_.str("");
-            sstream_ << tdloop->first << " = " << tdloop->second << " ns";
-            messenger_.detail(sstream_.str(), 1);
 
+        } else {
+            if (node.child("TraceDelay").child("global").empty()) {
+                throw invalid_argument(CriticalAttributeMessage("Global Trace Delay must be defined"));
+            } else {
+                for (pugi::xml_node_iterator tdit = node.child("TraceDelay").begin();
+                     tdit != node.child("TraceDelay").end(); ++tdit) {
+                    std::string name = tdit->name();
+                    unsigned int tdelay = tdit->attribute("value").as_uint();
+                    delays.insert(make_pair(name, tdelay));
+                }
+                globals->SetTraceDelay(delays);
+
+                sstream_ << "Trace Delays:";
+                messenger_.detail(sstream_.str());
+                for (std::map<std::string, unsigned int>::const_iterator tdloop =
+                        delays.begin(); tdloop != delays.end(); tdloop++) {
+                    sstream_.str("");
+                    sstream_ << tdloop->first << " = " << tdloop->second << " ns";
+                    messenger_.detail(sstream_.str(), 1);
+                }
+            }
         }
-    } else
-        throw invalid_argument(CriticalNodeMessage("TraceDelay"));
+    }else {
+        throw invalid_argument(CriticalNodeMessage("TraceDelay"));}
 
-    sstream_.str("");
+        sstream_.str("");
     if (!node.child("QdcCompression").empty())
         globals->SetQdcCompression(
                 node.child("QdcCompression").attribute("value").as_double());

--- a/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
@@ -92,11 +92,14 @@ void GlobalsXmlParser::ParseCfdNode(const pugi::xml_node &node, Globals *globals
                      parit != it->end(); ++parit)
                     pars.insert(std::make_pair(
                             parit->attribute("name").as_string(),
-                            std::make_pair(parit->child("Fraction").attribute("value").as_double(0.),
-                                           parit->child("Delay").attribute("value").as_double(0.))));
+                            std::make_pair(parit->child("Fraction").attribute(
+                                    "value").as_double(0.),
+                                           parit->child("Delay").attribute(
+                                                   "value").as_double(0.))));
         globals->SetCfdParameters(pars);
     } else
-        throw invalid_argument(CriticalNodeMessage(node.child("Parameters").name()));
+        throw invalid_argument(
+                CriticalNodeMessage(node.child("Parameters").name()));
     set<string> knownNodes = {"Parameters"};
     WarnOfUnknownChildren(node, knownNodes);
 }
@@ -113,7 +116,7 @@ string GlobalsXmlParser::ParseDescriptionNode(const pugi::xml_node &node) {
 /// parameters are critical to the function of the software. I the fitting node
 /// is present then the Parameters node must also be.
 void GlobalsXmlParser::ParseFittingNode(const pugi::xml_node &node,
-                                 Globals *globals) {
+                                        Globals *globals) {
     if (!node.child("SigmaBaselineThresh").empty())
         globals->SetSigmaBaselineThreshold(
                 node.child("SigmaBaselineThresh").attribute("value").as_double());
@@ -267,15 +270,27 @@ void GlobalsXmlParser::ParseTraceNode(const pugi::xml_node &node, Globals *globa
     messenger_.detail(sstream_.str());
     sstream_.str("");
 
-    if(!node.child("TraceDelay").empty()) {
-        globals->SetTraceDelay(
-                node.child("TraceDelay").attribute("value").as_uint());
+    if (!node.child("TraceDelay").empty()) {
+        std::map<std::string, unsigned int> delays;
+        for (pugi::xml_node_iterator tdit = node.child("TraceDelay").begin();
+             tdit != node.child("TraceDelay").end(); ++tdit) {
+            std::string name = tdit->name();
+            unsigned int tdelay = tdit->attribute("value").as_uint();
+            delays.insert(make_pair(name, tdelay));
+        }
+        globals->SetTraceDelay(delays);
+
+        sstream_ << "Trace Delays:";
+        messenger_.detail(sstream_.str());
+        for (std::map<std::string, unsigned int>::const_iterator tdloop =
+                delays.begin(); tdloop != delays.end(); tdloop++) {
+            sstream_.str("");
+            sstream_ << tdloop->first << " = " << tdloop->second << " ns";
+            messenger_.detail(sstream_.str(), 1);
+
+        }
     } else
         throw invalid_argument(CriticalNodeMessage("TraceDelay"));
-
-    sstream_ << "Trace Delay : " << globals->GetTraceDelayInNs() << " ns";
-    messenger_.detail(sstream_.str());
-    sstream_.str("");
 
     if (!node.child("QdcCompression").empty())
         globals->SetQdcCompression(

--- a/Analysis/Utkscan/share/utkscan/cfgs/examples/example.xml
+++ b/Analysis/Utkscan/share/utkscan/cfgs/examples/example.xml
@@ -292,6 +292,16 @@
 	                     come later in the trace. Default = 266
 	 * TraceDelay - The value of the trace delay from the set file used to 
 	                take the data. No Default value
+	                There is now 2 formats for the Trace Delay node, both are supported.
+	                The Old format
+	                    <TraceDelay unit="..." value="..."/>
+	                and the New format
+	                    <TraceDelay unit="...">
+	                        <global value="..."/>
+	                        <type:subtype value="..."/>
+	                    </TraceDelay>
+	                For the New format the global subnode is the only one required.
+
 	 * TraceLength - How long the traces are. Taken from the set file. No 
 	                 Default value
 	 * QdcCompression - Compression value for the trace QDC used when 
@@ -310,6 +320,12 @@
     -->
     <Trace>
         <TraceDelay unit="ns" value="344"/>
+        <!--
+        <TraceDelay unit="ns">
+            <global value="344"/>
+            <pulser:start value="296"/>
+        </TraceDelay>
+        -->
         <TraceLength unit="ns" value="496"/>
         <WaveformRange>
             <Range name="pulser:start">
@@ -347,7 +363,7 @@
       -->
     <Fitting>
         <SigmaBaselineThresh value="3.0"/>
-        <SiPmtSigmaBaselineThresh value="25.0"/>
+        <SiPmSigmaBaselineThresh value="25.0"/>
         <Parameters>
             <Pars name="vandle:small">
                 <Beta value="0.32969"/>


### PR DESCRIPTION
Allows us to have different type:subtype trace delays; This is the easy route for fixing #251 . This is needed for ORNL2016 data as M0 has a different delay than the rest of the modules. When calling GetTraceDelayInNS() you now can pass it a `type:subtype` string,  if it doesn't find a match in the map (or you don't pass it a string) it returns the global delay.  
It allows you to use the 'old' style (`<TraceDelay units="ns" value="264"/>`)  or the new style 
```
<TraceDelay units="ns">
         <global value="264"/> 
         <beta:double value="188"/>
         ...
</TraceDelay>
```
The global value is the only required subnode for the new style, the code will throw an error if it doesn't find it when parsing.
I have tested it with on kqxhc, as well as my Ubuntu 17.04 laptop. 
```
Linux Flavor = Ubuntu 17.04
Linux Kernel = 4.10.0-21-generic 
cmake version 3.7.2 
gcc (Ubuntu 6.3.0-12ubuntu2) 6.3.0 20170406 
GSL version = 2.3
```
