### PR TITLE
Various new histos

### DIFF
--- a/Analysis/Utkscan/core/include/DammPlotIds.hpp
+++ b/Analysis/Utkscan/core/include/DammPlotIds.hpp
@@ -103,8 +103,8 @@ namespace dammIds {
 
     ///in GeProcessor.hpp
     namespace ge {
-        const int OFFSET = 2999;//!< Offset for CloverProcessor
-        const int RANGE = 1;//!< Range for CloverProcessor
+        const int OFFSET = 2999;//!< Offset for GeProcessor
+        const int RANGE = 1;//!< Range for GeProcessor
     }
 
     ///in LogicProcessor.cpp

--- a/Analysis/Utkscan/processors/include/CloverProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/CloverProcessor.hpp
@@ -50,6 +50,7 @@ namespace dammIds {
         const int DD_TDIFF__GAMMA_GAMMA_ENERGY_SUM = 156;//!< Tdiff vs. Gamma-Gamma Energy sum
 
         const int DD_ADD_ENERGY__TIMEX = 170;//!< Addback Energy vs. Time
+        const int D_NONCYCGATEDENERGY = 200; //!<Same as D_ENERGY but without the cycling requirement, Useful for Cf and other tests
 
         //! Namespace for the beta gated Ge histograms
         namespace betaGated {
@@ -86,6 +87,7 @@ namespace dammIds {
             const int DD_ADD_ENERGY = 160;//!< Beta Gated Gamma-Gamma Addback
             const int DD_ADD_ENERGY_PROMPT = 161;//!< Beta Gated Gamma-Gamma Prompt addback
             const int DD_ADD_ENERGY__TIMEX = 180;//!< Beta Gated Addback Energy vs. Time
+            const int D_NONCYCGATEDENERGY = 210; //!<Same as D_ENERGY but without the cycling requirement, Useful for Cf and other tests
         }
 
         //! namespace for the multi-gated spectra

--- a/Analysis/Utkscan/processors/include/VandleProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/VandleProcessor.hpp
@@ -83,7 +83,8 @@ private:
     void FillVandleOnlyHists();
 
     void PlotTofHistograms(const double &tof, const double &cortof,const double &NCtof, const double &qdc,
-                           const unsigned int &barPlusStartLoc, const std::pair<unsigned int, unsigned int> &offset);
+                           const unsigned int &barPlusStartLoc, const std::pair<unsigned int, unsigned int> &offset,
+                           bool &calibrated );
 
     ///@return Returns a pair of the appropriate offsets based off the VANDLE bar type <calibrated, NonCalibrated>
     ///@param [in] type : The type of bar that we are dealing with

--- a/Analysis/Utkscan/processors/include/VandleProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/VandleProcessor.hpp
@@ -82,12 +82,12 @@ private:
     ///Fill up the basic histograms
     void FillVandleOnlyHists();
 
-    void PlotTofHistograms(const double &tof, const double &cortof, const double &qdc,
-                           const unsigned int &barPlusStartLoc, const unsigned int &offset);
+    void PlotTofHistograms(const double &tof, const double &cortof,const double &NCtof, const double &qdc,
+                           const unsigned int &barPlusStartLoc, const std::pair<unsigned int, unsigned int> &offset);
 
-    ///@return Returns the appropriate offset based off the VANDLE bar type
+    ///@return Returns a pair of the appropriate offsets based off the VANDLE bar type <calibrated, NonCalibrated>
     ///@param [in] type : The type of bar that we are dealing with
-    unsigned int ReturnOffset(const std::string &type);
+    std::pair<unsigned int, unsigned int> ReturnOffset(const std::string &type);
 
     BarMap bars_;//!< A map to hold all the bars
     TimingMap starts_;//!< A map to to hold all the starts

--- a/Analysis/Utkscan/processors/source/CloverProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/CloverProcessor.cpp
@@ -259,6 +259,11 @@ void CloverProcessor::DeclarePlots(void) {
     DeclareHistogram1D(multi::betaGated::D_ADD_ENERGY_TOTAL, energyBins1,
                        "Beta gated gamma total multi-gated");
 
+    DeclareHistogram1D(D_NONCYCGATEDENERGY,energyBins1,"Non Cycle Gated Gamma"
+            " Singles");
+    DeclareHistogram1D(betaGated::D_NONCYCGATEDENERGY,energyBins1,"Beta Gated"
+            " Non Cycle Gated Gamma Singles");
+
     // for each clover
     for (unsigned int i = 0; i < numClovers; i++) {
         stringstream ss;
@@ -509,6 +514,19 @@ bool CloverProcessor::Process(RawEvent &event) {
                                           "while trying to get Beta status.\n");
         throw;
     }
+    for (vector<ChanEvent*>::iterator it1 = geEvents_.begin();
+         it1 != geEvents_.end(); ++it1) {
+        ChanEvent *chan = *it1;
+
+        double gEnergy = chan->GetCalibratedEnergy();
+        if (gEnergy < gammaThreshold_)
+            continue;
+        if (hasBeta) {
+            plot(betaGated::D_NONCYCGATEDENERGY, gEnergy);
+        }
+        plot(D_NONCYCGATEDENERGY, gEnergy);
+    }
+
 
     /** Place Cycle is activated by BeamOn event and deactivated by TapeMove
      *  This condition will therefore skip events registered during
@@ -533,7 +551,7 @@ bool CloverProcessor::Process(RawEvent &event) {
 
     // Note that geEvents_ vector holds only good events (matched
     // low & high gain). See PreProcess
-    for (vector<ChanEvent *>::iterator it1 = geEvents_.begin();
+      for (vector<ChanEvent *>::iterator it1 = geEvents_.begin();
          it1 != geEvents_.end(); ++it1) {
         ChanEvent *chan = *it1;
 

--- a/Analysis/Utkscan/processors/source/DoubleBetaProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/DoubleBetaProcessor.cpp
@@ -19,6 +19,7 @@ namespace dammIds {
         const int DD_TDIFF = 2;//!< ID to plot the Time Difference between ends
         const int DD_PP = 3;//!< ID to plot the phase-phase for your favorite bar (0)
         const int DD_QDCTDIFF = 4;//!< QDC vs. TDiff for your favorite bar (0)
+        const int DD_BETAMAXXVAL = 5;//!< Max Value in your favorite beta PMT
     }
 }
 
@@ -33,8 +34,9 @@ DoubleBetaProcessor::DoubleBetaProcessor() :
 void DoubleBetaProcessor::DeclarePlots(void) {
     DeclareHistogram2D(DD_QDC, SD, S3, "Location vs. Coincident QDC");
     DeclareHistogram2D(DD_TDIFF, SB, S3, "Location vs. Time Difference");
-    DeclareHistogram2D(DD_PP, SC, SC, "Phase vs. Phase - Bar 0 Only");
-    DeclareHistogram2D(DD_QDCTDIFF, SC, SE, "TimeDiff vs. Coincident QDC");
+    DeclareHistogram2D(DD_PP, SC, SC,"Phase vs. Phase - Bar 0 Only");
+    DeclareHistogram2D(DD_QDCTDIFF, SC, SE,"TimeDiff vs. Coincident QDC");
+    DeclareHistogram2D(DD_BETAMAXXVAL,SD,S3,"Max Value in the Trace");
 }
 
 bool DoubleBetaProcessor::PreProcess(RawEvent &event) {
@@ -70,13 +72,16 @@ bool DoubleBetaProcessor::PreProcess(RawEvent &event) {
         unsigned int barNum = (*it).first.first;
         plot(DD_QDC, (*it).second.GetLeftSide().GetTraceQdc(), barNum * 2);
         plot(DD_QDC, (*it).second.GetRightSide().GetTraceQdc(), barNum * 2 + 1);
-        plot(DD_TDIFF, (*it).second.GetTimeDifference() * resolution + offset,
-             barNum);
-        if (barNum == 0) {
-            plot(DD_PP, (*it).second.GetLeftSide().GetPhaseInNs() * resolution,
-                 (*it).second.GetRightSide().GetPhaseInNs() * resolution);
-            plot(DD_QDCTDIFF,
-                 (*it).second.GetTimeDifference() * resolution + offset,
+        plot(DD_TDIFF, (*it).second.GetTimeDifference()*resolution + offset, barNum);
+        plot(DD_BETAMAXXVAL,(*it).second.GetLeftSide().GetMaximumValue(),
+             barNum*2);
+        plot(DD_BETAMAXXVAL,(*it).second.GetRightSide().GetMaximumValue(),
+             barNum*2+1);
+
+        if(barNum == 0) {
+            plot(DD_PP, (*it).second.GetLeftSide().GetPhaseInNs()*resolution,
+                 (*it).second.GetRightSide().GetPhaseInNs()*resolution);
+            plot(DD_QDCTDIFF, (*it).second.GetTimeDifference()*resolution+offset,
                  (*it).second.GetQdc());
         }
     }

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -30,14 +30,15 @@ namespace dammIds {
         const unsigned int BIGNOCALTYPE_OFFSET = 120;//!< Offset for Unclaibrated hists LARGE BARS
 
         const int DD_TQDCBARS = 0;//!< QDC for the bars
-        const int DD_TIMEDIFFBARS = 1;//!< time difference in the bars
-        const int DD_TOFBARS = 2;//!< time of flight for the bars
-        const int DD_CORTOFBARS = 3;//!< corrected time of flight
-        const int DD_TQDCAVEVSTOF = 4;//!< Ave QDC vs. ToF
-        const int DD_TQDCAVEVSCORTOF = 5;//!< Ave QDC vs. Cor ToF
-        const int DD_GAMMAENERGYVSTOF = 6;//!< Gamma Energy vs. ToF
-        const int DD_TQDCAVEVSTOF_VETO = 7;//!< QDC vs. ToF - Vetoed
-        const int DD_TOFBARS_VETO = 8;//!< ToF - Vetoed
+        const int DD_MAXIMUMBARS  = 1;//!< Maximum values for the bars
+        const int DD_TIMEDIFFBARS = 2;//!< time difference in the bars
+        const int DD_TOFBARS = 3;//!< time of flight for the bars
+        const int DD_CORTOFBARS = 4;//!< corrected time of flight
+        const int DD_TQDCAVEVSTOF = 5;//!< Ave QDC vs. ToF
+        const int DD_TQDCAVEVSCORTOF = 6;//!< Ave QDC vs. Cor ToF
+        const int DD_GAMMAENERGYVSTOF = 7;//!< Gamma Energy vs. ToF
+        const int DD_TQDCAVEVSTOF_VETO = 8;//!< QDC vs. ToF - Vetoed
+        const int DD_TOFBARS_VETO = 9;//!< ToF - Vetoed
 
         const int D_DEBUGGING = 0 + DEBUGGING_OFFSET;//!< Debugging countable problems
         const int DD_DEBUGGING = 1 + DEBUGGING_OFFSET;//!< 2D Hist to count problems
@@ -70,6 +71,7 @@ void VandleProcessor::DeclarePlots(void) {
     for(set<string>::iterator it = requestedTypes_.begin(); it != requestedTypes_.end(); it++) {
         pair<unsigned int,unsigned int> offset = ReturnOffset(*it);
         DeclareHistogram2D(DD_TQDCBARS + offset.first, SD, S8, "Det Loc vs Trace QDC - Left Even - Right Odd");
+        DeclareHistogram2D(DD_MAXIMUMBARS + offset.first, SD, S8,"Det Loc vs Maximum - Left Even - Right Odd");
         DeclareHistogram2D(DD_TIMEDIFFBARS + offset.first, SB, S6, "Bars vs. Time Differences");
         DeclareHistogram2D(DD_TOFBARS + offset.first, SC, S8, "Bar vs. Time of Flight");
         DeclareHistogram2D(DD_CORTOFBARS + offset.first, SC, S8, "Bar vs  Cor Time of Flight");
@@ -161,11 +163,13 @@ void VandleProcessor::AnalyzeBarStarts(const BarDetector &bar, unsigned int &bar
             unsigned int startLoc = (*itStart).first.first;
             BarDetector start = (*itStart).second;
 
+            bool caled = ( bar.GetCalibration().GetZ0() != 0 );
             double tof = bar.GetCorTimeAve() - start.GetCorTimeAve() + bar.GetCalibration().GetTofOffset(startLoc);
             double corTof = CorrectTOF(tof, bar.GetFlightPath(), bar.GetCalibration().GetZ0());
             double NCtof = bar.GetCorTimeAve() - start.GetCorTimeAve() ;
 
-            PlotTofHistograms(tof, corTof,NCtof, bar.GetQdc(), barLoc * numStarts_ + startLoc, ReturnOffset(bar.GetType()));
+            PlotTofHistograms(tof, corTof,NCtof, bar.GetQdc(), barLoc * numStarts_ + startLoc,
+                              ReturnOffset(bar.GetType()),caled);
         }
 }
 
@@ -177,24 +181,31 @@ void VandleProcessor::AnalyzeStarts(const BarDetector &bar, unsigned int &barLoc
             unsigned int startLoc = (*itStart).first.first;
             HighResTimingData start = (*itStart).second;
 
+            bool caled = ( bar.GetCalibration().GetZ0() != 0 );
             double tof = bar.GetCorTimeAve() - start.GetWalkCorrectedTime() + bar.GetCalibration().GetTofOffset(startLoc);
             double corTof = CorrectTOF(tof, bar.GetFlightPath(), bar.GetCalibration().GetZ0());
             double NCtof =bar.GetCorTimeAve() - start.GetWalkCorrectedTime() ;
 
-            PlotTofHistograms(tof, corTof, NCtof,bar.GetQdc(), barLoc * numStarts_ + startLoc, ReturnOffset(bar.GetType()));
+            PlotTofHistograms(tof, corTof, NCtof,bar.GetQdc(), barLoc * numStarts_ + startLoc,
+                              ReturnOffset(bar.GetType()),caled);
         }
 }
 
 void VandleProcessor::PlotTofHistograms(const double &tof, const double &cortof,const double &NCtof, const double &qdc,
-                                        const unsigned int &barPlusStartLoc, const pair<unsigned int, unsigned int>&offset) {
+                                        const unsigned int &barPlusStartLoc,
+                                        const pair<unsigned int, unsigned int>&offset ,bool &calibrated) {
+
     plot(DD_TOFBARS + offset.first, tof * plotMult_ + plotOffset_, barPlusStartLoc);
-    plot(DD_TQDCAVEVSTOF + offset.first, tof * plotMult_ + plotOffset_, qdc / qdcComp_);
-
     plot(DD_CORTOFBARS + offset.first, cortof * plotMult_ + plotOffset_, barPlusStartLoc);
-    plot(DD_TQDCAVEVSCORTOF + offset.first, cortof * plotMult_ + plotOffset_, qdc / qdcComp_);
 
+    //making these histograms only plot if t cal exists. since no tcal causes strange looking behavior.
+    if (calibrated) {
+        plot(DD_TQDCAVEVSTOF + offset.first, tof * plotMult_ + plotOffset_, qdc / qdcComp_);
+        plot(DD_TQDCAVEVSCORTOF + offset.first, cortof * plotMult_ + plotOffset_, qdc / qdcComp_);
+    }
     /*Plotting the Non Time Calibrated Histograms;
     *The ones above would be the same as these when no time calibration is present in the Config.xml
+     * This allows for easier timecals since we dont have to rerun the data before we can run timecal.bash
     */
     plot(DD_TOFBARS + offset.second, NCtof* plotMult_ + plotOffset_, barPlusStartLoc);
     plot(DD_TQDCAVEVSTOF + offset.second, NCtof* plotMult_ + plotOffset_, qdc / qdcComp_);
@@ -218,12 +229,15 @@ void VandleProcessor::FillVandleOnlyHists(void) {
         TimingDefs::TimingIdentifier barId = (*it).first;
         unsigned int OFFSET = ReturnOffset(barId.second).first;
         unsigned int NOCALOFFSET = ReturnOffset(barId.second).second;
+        double NoCalTDiff = (*it).second.GetLeftSide().GetHighResTimeInNs()-(*it).second.GetRightSide().GetHighResTimeInNs();
+        
+        plot(DD_MAXIMUMBARS + OFFSET,(*it).second.GetLeftSide().GetMaximumValue(), barId.first*2);
+        plot(DD_MAXIMUMBARS + OFFSET,(*it).second.GetRightSide().GetMaximumValue(), barId.first*2+1);
 
         plot(DD_TQDCBARS + OFFSET, (*it).second.GetLeftSide().GetTraceQdc() / qdcComp_, barId.first * 2);
         plot(DD_TQDCBARS + OFFSET, (*it).second.GetRightSide().GetTraceQdc() / qdcComp_, barId.first * 2 + 1);
-        plot(DD_TIMEDIFFBARS + OFFSET, (*it).second.GetTimeDifference() * plotMult_ + plotOffset_, barId.first);
 
-        double NoCalTDiff = (*it).second.GetLeftSide().GetHighResTimeInNs()-(*it).second.GetRightSide().GetHighResTimeInNs();
+        plot(DD_TIMEDIFFBARS + OFFSET, (*it).second.GetTimeDifference() * plotMult_ + plotOffset_, barId.first);
         plot(DD_TIMEDIFFBARS + NOCALOFFSET, NoCalTDiff* plotMult_ + plotOffset_, barId.first);
     }
 }

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -25,6 +25,9 @@ namespace dammIds {
         const unsigned int BIG_OFFSET = 20; //!< Offset for big bars
         const unsigned int MED_OFFSET = 40;//!< Offset for medium bars
         const unsigned int DEBUGGING_OFFSET = 60;//!< Offset for debugging hists
+        const unsigned int SMALLNOCAL_OFFSET = 100;//!< Offset for Unclaibrated hists
+        const unsigned int MEDNOCALTYPE_OFFSET = 110;//!< Offset for Unclaibrated hists MEDIUM BARS
+        const unsigned int BIGNOCALTYPE_OFFSET = 120;//!< Offset for Unclaibrated hists LARGE BARS
 
         const int DD_TQDCBARS = 0;//!< QDC for the bars
         const int DD_TIMEDIFFBARS = 1;//!< time difference in the bars
@@ -65,15 +68,20 @@ VandleProcessor::VandleProcessor(const std::vector<std::string> &typeList, const
 
 void VandleProcessor::DeclarePlots(void) {
     for(set<string>::iterator it = requestedTypes_.begin(); it != requestedTypes_.end(); it++) {
-        unsigned int offset = ReturnOffset(*it);
-        DeclareHistogram2D(DD_TQDCBARS + offset, SD, S8, "Det Loc vs Trace QDC - Left Even - Right Odd");
-        DeclareHistogram2D(DD_TIMEDIFFBARS + offset, SB, S6, "Bars vs. Time Differences");
-        DeclareHistogram2D(DD_TOFBARS + offset, SC, S8, "Bar vs. Time of Flight");
-        DeclareHistogram2D(DD_CORTOFBARS + offset, SC, S8, "Bar vs  Cor Time of Flight");
-        DeclareHistogram2D(DD_TQDCAVEVSTOF + offset, SC, SD, "<E> vs. TOF(0.5ns/bin)");
-        DeclareHistogram2D(DD_TQDCAVEVSCORTOF + offset, SC, SD, "<E> vs. CorTOF(0.5ns/bin)");
-        DeclareHistogram2D(DD_GAMMAENERGYVSTOF + offset, SC, S9, "C-ToF vs. E_gamma");
+        pair<unsigned int,unsigned int> offset = ReturnOffset(*it);
+        DeclareHistogram2D(DD_TQDCBARS + offset.first, SD, S8, "Det Loc vs Trace QDC - Left Even - Right Odd");
+        DeclareHistogram2D(DD_TIMEDIFFBARS + offset.first, SB, S6, "Bars vs. Time Differences");
+        DeclareHistogram2D(DD_TOFBARS + offset.first, SC, S8, "Bar vs. Time of Flight");
+        DeclareHistogram2D(DD_CORTOFBARS + offset.first, SC, S8, "Bar vs  Cor Time of Flight");
+        DeclareHistogram2D(DD_TQDCAVEVSTOF + offset.first, SC, SD, "<E> vs. TOF(0.5ns/bin)");
+        DeclareHistogram2D(DD_TQDCAVEVSCORTOF + offset.first, SC, SD, "<E> vs. CorTOF(0.5ns/bin)");
+        DeclareHistogram2D(DD_GAMMAENERGYVSTOF + offset.first, SC, S9, "C-ToF vs. E_gamma");
+
+        DeclareHistogram2D(DD_TIMEDIFFBARS + offset.second, SB, S6, "UNCALIBRATED: Bars vs. Time Differences (0.5ns/bin)");
+        DeclareHistogram2D(DD_TOFBARS + offset.second, SC, S8, "UNCALIBRATED: Bar vs. Time of Flight (0.5ns/bin)");
+        DeclareHistogram2D(DD_TQDCAVEVSTOF+ offset.second, SC, S8, "UNCALIBRATED: <E> vs. TOF (0.5ns/bin)");
     }
+
     DeclareHistogram1D(D_DEBUGGING, S5, "1D Debugging");
     DeclareHistogram2D(DD_DEBUGGING, S8, S8, "2D Debugging");
 }
@@ -155,8 +163,9 @@ void VandleProcessor::AnalyzeBarStarts(const BarDetector &bar, unsigned int &bar
 
             double tof = bar.GetCorTimeAve() - start.GetCorTimeAve() + bar.GetCalibration().GetTofOffset(startLoc);
             double corTof = CorrectTOF(tof, bar.GetFlightPath(), bar.GetCalibration().GetZ0());
+            double NCtof = bar.GetCorTimeAve() - start.GetCorTimeAve() ;
 
-            PlotTofHistograms(tof, corTof, bar.GetQdc(), barLoc * numStarts_ + startLoc, ReturnOffset(bar.GetType()));
+            PlotTofHistograms(tof, corTof,NCtof, bar.GetQdc(), barLoc * numStarts_ + startLoc, ReturnOffset(bar.GetType()));
         }
 }
 
@@ -170,27 +179,36 @@ void VandleProcessor::AnalyzeStarts(const BarDetector &bar, unsigned int &barLoc
 
             double tof = bar.GetCorTimeAve() - start.GetWalkCorrectedTime() + bar.GetCalibration().GetTofOffset(startLoc);
             double corTof = CorrectTOF(tof, bar.GetFlightPath(), bar.GetCalibration().GetZ0());
+            double NCtof =bar.GetCorTimeAve() - start.GetWalkCorrectedTime() ;
 
-            PlotTofHistograms(tof, corTof, bar.GetQdc(), barLoc * numStarts_ + startLoc, ReturnOffset(bar.GetType()));
+            PlotTofHistograms(tof, corTof, NCtof,bar.GetQdc(), barLoc * numStarts_ + startLoc, ReturnOffset(bar.GetType()));
         }
 }
 
-void VandleProcessor::PlotTofHistograms(const double &tof, const double &cortof, const double &qdc,
-                                        const unsigned int &barPlusStartLoc, const unsigned int &offset) {
-    plot(DD_TOFBARS + offset, tof * plotMult_ + plotOffset_, barPlusStartLoc);
-    plot(DD_TQDCAVEVSTOF + offset, tof * plotMult_ + plotOffset_, qdc / qdcComp_);
+void VandleProcessor::PlotTofHistograms(const double &tof, const double &cortof,const double &NCtof, const double &qdc,
+                                        const unsigned int &barPlusStartLoc, const pair<unsigned int, unsigned int>&offset) {
+    plot(DD_TOFBARS + offset.first, tof * plotMult_ + plotOffset_, barPlusStartLoc);
+    plot(DD_TQDCAVEVSTOF + offset.first, tof * plotMult_ + plotOffset_, qdc / qdcComp_);
 
-    plot(DD_CORTOFBARS + offset, cortof * plotMult_ + plotOffset_, barPlusStartLoc);
-    plot(DD_TQDCAVEVSCORTOF + offset, cortof * plotMult_ + plotOffset_, qdc / qdcComp_);
+    plot(DD_CORTOFBARS + offset.first, cortof * plotMult_ + plotOffset_, barPlusStartLoc);
+    plot(DD_TQDCAVEVSCORTOF + offset.first, cortof * plotMult_ + plotOffset_, qdc / qdcComp_);
+
+    /*Plotting the Non Time Calibrated Histograms;
+    *The ones above would be the same as these when no time calibration is present in the Config.xml
+    */
+    plot(DD_TOFBARS + offset.second, NCtof* plotMult_ + plotOffset_, barPlusStartLoc);
+    plot(DD_TQDCAVEVSTOF + offset.second, NCtof* plotMult_ + plotOffset_, qdc / qdcComp_);
+
+
 
     if (geSummary_) {
         if (geSummary_->GetMult() > 0) {
             const vector<ChanEvent *> &geList = geSummary_->GetList();
             for (vector<ChanEvent *>::const_iterator itGe = geList.begin(); itGe != geList.end(); itGe++)
-                plot(DD_GAMMAENERGYVSTOF + offset, (*itGe)->GetCalibratedEnergy(), tof);
+                plot(DD_GAMMAENERGYVSTOF + offset.first, (*itGe)->GetCalibratedEnergy(), tof);
         } else {
-            plot(DD_TQDCAVEVSTOF_VETO + offset, tof, qdc / qdcComp_);
-            plot(DD_TOFBARS_VETO + offset, tof, barPlusStartLoc);
+            plot(DD_TQDCAVEVSTOF_VETO + offset.first, tof, qdc / qdcComp_);
+            plot(DD_TOFBARS_VETO + offset.first, tof, barPlusStartLoc);
         }
     }
 }
@@ -198,20 +216,24 @@ void VandleProcessor::PlotTofHistograms(const double &tof, const double &cortof,
 void VandleProcessor::FillVandleOnlyHists(void) {
     for (BarMap::const_iterator it = bars_.begin(); it != bars_.end(); it++) {
         TimingDefs::TimingIdentifier barId = (*it).first;
-        unsigned int OFFSET = ReturnOffset(barId.second);
+        unsigned int OFFSET = ReturnOffset(barId.second).first;
+        unsigned int NOCALOFFSET = ReturnOffset(barId.second).second;
 
         plot(DD_TQDCBARS + OFFSET, (*it).second.GetLeftSide().GetTraceQdc() / qdcComp_, barId.first * 2);
         plot(DD_TQDCBARS + OFFSET, (*it).second.GetRightSide().GetTraceQdc() / qdcComp_, barId.first * 2 + 1);
         plot(DD_TIMEDIFFBARS + OFFSET, (*it).second.GetTimeDifference() * plotMult_ + plotOffset_, barId.first);
+
+        double NoCalTDiff = (*it).second.GetLeftSide().GetHighResTimeInNs()-(*it).second.GetRightSide().GetHighResTimeInNs();
+        plot(DD_TIMEDIFFBARS + NOCALOFFSET, NoCalTDiff* plotMult_ + plotOffset_, barId.first);
     }
 }
 
-unsigned int VandleProcessor::ReturnOffset(const std::string &type) {
+std::pair<unsigned int, unsigned int> VandleProcessor::ReturnOffset(const std::string &type) {
     if (type == "small")
-        return 0;
+        return (make_pair((unsigned int )0,SMALLNOCAL_OFFSET));
     if (type == "big")
-        return (BIG_OFFSET);
+        return (make_pair(BIG_OFFSET,BIGNOCALTYPE_OFFSET));
     if (type == "medium")
-        return (MED_OFFSET);
-    return numeric_limits<unsigned int>::max();
+        return (make_pair(MED_OFFSET,MEDNOCALTYPE_OFFSET));
+    return make_pair(numeric_limits<unsigned int>::max(),numeric_limits<unsigned int>::max());
 }


### PR DESCRIPTION
I had these to add before #269 / #282. 

Robert requested most of these during the IS632 experiment .

The list of new plots (in commit order):
1) Max Value of the trace vs beta detector (Even Left, Odd Right)
2) Always uncalibrated histograms for the VandleProcessor. These include Tdiff, BarNum vs ToF, and (per request ) QDC vs ToF. This last one is just to see that we are getting Something. These also all have "UNCALIBRATED:" in the histogram name; and are away from the usual ids (3300-3329)
3) Clover sums (2500 and 2510) without the cycling requirement. This is useful for cf or when there is a problem with the cycling logic.
4) Re-added the max value plot for the vandle bars and put the Average QDC vs (cor)ToF plots back to requiring a Time cal since they look very odd without one; and the need for always plotting these is alleviated by point 2

the last commit is just a small comment update in the DammPlotIds.hpp 