### PR TITLE
added some global defaults

### DIFF
--- a/Analysis/Resources/include/ChannelConfiguration.hpp
+++ b/Analysis/Resources/include/ChannelConfiguration.hpp
@@ -72,7 +72,7 @@ public:
     unsigned int GetTraceDelayInSamples() const { return traceDelayInSamples_; }
 
     ///@return The waveform bounds in samples
-    std::pair<unsigned int, unsigned int> GetWaveformBoundsInSamples() const { return waveformBoundsInSeconds_; }
+    std::pair<unsigned int, unsigned int> GetWaveformBoundsInSamples() const { return waveformBoundsInSamples_; }
 
     ///Check if an identifier has a tag
     ///@param [in] s : the tag to search for
@@ -132,7 +132,7 @@ public:
 
     ///Sets the bounds for the waveform measured from the maximum value of the trace in trace samples.
     ///@param[in] a : A pair containing the low bound (first) and high bound (second) for the waveform.
-    void SetWaveformBoundsInSamples(const std::pair<unsigned int, unsigned int> &a) { waveformBoundsInSeconds_ = a; }
+    void SetWaveformBoundsInSamples(const std::pair<unsigned int, unsigned int> &a) { waveformBoundsInSamples_ = a; }
 
     ///Zeroes some of the variables in the class. The DAMM ID and detector location variable are reset to -1 and the
     /// detector type and sub type are both reset to "" when an identifier object is zeroed.
@@ -191,7 +191,7 @@ private:
     unsigned int traceDelayInSamples_; ///< The trace delay to help find the location of waveforms in traces
     TrapFilterParameters triggerFilterParameters_; ///< Parameters to use for trigger filter calculations
     std::string type_; ///< Specifies the detector type
-    std::pair<unsigned int, unsigned int> waveformBoundsInSeconds_; ///< The waveform range for the channel
+    std::pair<unsigned int, unsigned int> waveformBoundsInSamples_; ///< The waveform range for the channel
 };
 
 

--- a/Analysis/ScanLibraries/source/Unpacker.cpp
+++ b/Analysis/ScanLibraries/source/Unpacker.cpp
@@ -230,20 +230,25 @@ void Unpacker::InitializeDataMask(const std::string &firmware, const unsigned in
     if (frequency == 0) {
         unsigned int modCounter = 0;
         pugi::xml_node node = XmlInterface::get(firmware)->GetDocument()->child("Configuration").child("Map");
+        unsigned int globalFreq_ = node.attribute("frequency").as_uint();
+        string globalFirm_ = node.attribute("firmware").as_string();
+
         for (pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it, modCounter++) {
             if (it->attribute("number").empty())
                 throw invalid_argument("Unpacker::InitializeDataMask - Unable to read the \"number\" attribute from "
                                                "the module in position #" + to_string(modCounter) + "(0 counting)");
-            if (it->attribute("firmware").empty())
+            if (it->attribute("firmware").empty()&& globalFirm_.empty())
                 throw invalid_argument("Unpacker::InitializeDataMask - Unable to read the \"firmware\" attribute from"
-                                               " the /Configuration/Map/Module/" + to_string(modCounter));
-            if (it->attribute("frequency").empty())
+                                               " the /Configuration/Map/Module/" + to_string(modCounter) +
+                                       " and the Global default is not set");
+            if (it->attribute("frequency").empty()&& globalFreq_==0)
                 throw invalid_argument("Unpacker::InitializeDataMask - Unable to read the \"frequency\" attribute from"
-                                               " the /Configuration/Map/Module/" + to_string(modCounter));
+                                               " the /Configuration/Map/Module/" + to_string(modCounter)+
+                                       " and the Global default is not set");
 
             maskMap_.insert(make_pair(it->attribute("number").as_uint(),
-                                      make_pair(it->attribute("firmware").as_string(),
-                                                it->attribute("frequency").as_uint())));
+                                      make_pair(it->attribute("firmware").as_string(globalFirm_.c_str()),
+                                                it->attribute("frequency").as_uint(globalFreq_))));
         }
     } else {
         mask_.SetFrequency(frequency);

--- a/Analysis/ScanLibraries/source/Unpacker.cpp
+++ b/Analysis/ScanLibraries/source/Unpacker.cpp
@@ -16,6 +16,7 @@
 
 #include <cstring>
 
+#include "Exceptions.hpp"
 #include "Unpacker.hpp"
 #include "XiaData.hpp"
 #include "XiaListModeDataDecoder.hpp"
@@ -235,14 +236,15 @@ void Unpacker::InitializeDataMask(const std::string &firmware, const unsigned in
 
         for (pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it, modCounter++) {
             if (it->attribute("number").empty())
-                throw invalid_argument("Unpacker::InitializeDataMask - Unable to read the \"number\" attribute from "
+                throw IOException("Unpacker::InitializeDataMask - Unable to read the \"number\" attribute "
+                                                               "from "
                                                "the module in position #" + to_string(modCounter) + "(0 counting)");
             if (it->attribute("firmware").empty()&& globalFirm_.empty())
-                throw invalid_argument("Unpacker::InitializeDataMask - Unable to read the \"firmware\" attribute from"
+                throw IOException("Unpacker::InitializeDataMask - Unable to read the \"firmware\" attribute from"
                                                " the /Configuration/Map/Module/" + to_string(modCounter) +
                                        " and the Global default is not set");
             if (it->attribute("frequency").empty()&& globalFreq_==0)
-                throw invalid_argument("Unpacker::InitializeDataMask - Unable to read the \"frequency\" attribute from"
+                throw IOException("Unpacker::InitializeDataMask - Unable to read the \"frequency\" attribute from"
                                                " the /Configuration/Map/Module/" + to_string(modCounter)+
                                        " and the Global default is not set");
 

--- a/Analysis/Utkscan/core/include/MapNodeXmlParser.hpp
+++ b/Analysis/Utkscan/core/include/MapNodeXmlParser.hpp
@@ -71,7 +71,8 @@ private:
     ///@param[in] globals : A pointer to the globals class so we can set the
     /// values that we need.
     ///@throw invalid_argument If the WaveformRange is missing
-    void ParseTraceNode(const pugi::xml_node &node, ChannelConfiguration &config, const bool &isVerbose);
+    void ParseTraceNode(const pugi::xml_node &node, ChannelConfiguration &config, const int &mod_freq,const double &mod_TD
+            ,const bool &isVerbose);
 
     ///Parses the Trace node from the xml configuration file.
     ///@param[in] node : The node that we are going to parse

--- a/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
@@ -28,9 +28,9 @@ void MapNodeXmlParser::ParseNode(DetectorLibrary *lib) {
                     false);
     double globalTraceDelay = map.attribute("TraceDelay").as_double(-999);
     if (globalTraceDelay <= 0)
-        throw invalid_argument("TraceDelay must be set and greater than 0; This goes the map node head, near the verbose flag");
+        throw GeneralException("MapNodeXmlParser::ParseNode : Global TraceDelay must be set and greater than 0");
 
-    double globalModFreq = map.attribute("frequency").as_int(-1);
+    int globalModFreq = map.attribute("frequency").as_int(-1);
 
     TreeCorrelator *tree = TreeCorrelator::get();
 
@@ -57,9 +57,9 @@ void MapNodeXmlParser::ParseNode(DetectorLibrary *lib) {
             messenger_.detail(sstream_.str(),1);
             sstream_.str("");
 
-        }else if (isVerbose==false && module_TdelayNs != globalTraceDelay){
+        }else if (!isVerbose && module_TdelayNs != globalTraceDelay){
             if (module_number ==0){
-                sstream_ <<"Modules not using the Global Trace Delay value:: ("<<globalTraceDelay<<" ns)";
+                sstream_ <<"Modules not using the Global Trace Delay value: ("<<globalTraceDelay<<" ns)";
                 messenger_.detail(sstream_.str(),1);
                 sstream_.str("");
             }
@@ -116,11 +116,10 @@ void MapNodeXmlParser::ParseNode(DetectorLibrary *lib) {
                 sstream_.str("");
             }
 
-            bool isVandle;
+            bool isVandle = false;
             if (chanCfg.GetType()=="vandle")
                 isVandle = true;
-            else
-                isVandle = false;
+
 
             if (channel.child("Calibration").text())
                 ParseCalibrations(channel.child("Calibration"), chanCfg, isVerbose);
@@ -234,8 +233,8 @@ void MapNodeXmlParser::ParseTraceNode(const pugi::xml_node &node, ChannelConfigu
 
     config.SetDiscriminationStartInSamples(node.attribute("DiscriminationStart").as_uint(DefaultConfig::discrimStart));
     config.SetBaselineThreshold(node.attribute("baselineThreshold").as_double(DefaultConfig::baselineThreshold));
-    config.SetWaveformBoundsInSamples(make_pair(node.attribute("RangeLow").as_int(DefaultConfig::waveformLow),
-                                                node.attribute("RangeHigh").as_int(DefaultConfig::waveformHigh)));
+    config.SetWaveformBoundsInSamples(make_pair(node.attribute("RangeLow").as_uint(DefaultConfig::waveformLow),
+                                                node.attribute("RangeHigh").as_uint(DefaultConfig::waveformHigh)));
 
         ///since the frequency is input as a normal integer we must convert it to the correct value (250 -> 250 MHz),
         ///before we can use it to convert to the # of samples


### PR DESCRIPTION

1) Enabled global and module specific traceDelays in addition to the per channel ones, as well as reverted the units to ns (from samples). I do a conversion based on the frequency, this makes the value we put into Pixie  and whats in the config file the same base unit (seconds). This is how it was done before. I believe this will reduce some headache when making config files during experiments

2) Enabled Global Firmware and Frequency for use in nonmixed setups. 

I put both of these in the highest <Map> line; and the TraceDelay is required here, the Firm/Freq is only required to be set either here or in the module. The Module line overrides the global for that module, and similarly the per channel value overrides the module and global. This ensures that they are at least something for every module. 

I also changed when the MapNodeParser enters the channel node child parsers, so that the Trace and Fit child nodes are always set if the channel is a Vandle type since the defaults are for vandle:medium anyways. Again if it exists it should override the default behavior.

All of these changes make the transition to the new Dev style much easier, as well as keeping the config file from growing to monstrous  for full experiments. 

I have been using these for the last couple days without issue, with 17N data as well as the ORNL2016 data (which requires that the first module have a different Trace Delay than the rest)