### PR TITLE
adding Root Tree Output to VandleProcessor

### DIFF
--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -46,10 +46,11 @@
 //These headers are for handling experiment specific processing.
 #include "E11027Processor.hpp"
 #include "TemplateExpProcessor.hpp"
-#include "VandleOrnl2012Processor.hpp"
+
 
 #ifdef useroot //Some processors REQUIRE ROOT to function
 #include "Anl1471Processor.hpp"
+#include "VandleOrnl2012Processor.hpp"
 #include "IS600Processor.hpp"
 #include "RootProcessor.hpp"
 #include "TwoChanTimingProcessor.hpp"

--- a/Analysis/Utkscan/processors/include/VandleProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/VandleProcessor.hpp
@@ -17,6 +17,10 @@
 #include <set>
 #include <string>
 
+#include "TFile.h"
+#include "TTree.h"
+#include "TVector.h"
+
 #include "BarDetector.hpp"
 #include "EventProcessor.hpp"
 #include "HighResTimingData.hpp"
@@ -28,7 +32,10 @@ public:
     VandleProcessor();
 
     ///Default Destructor */
-    ~VandleProcessor() {};
+    ~VandleProcessor() {
+        TFile_tree->Write();
+        TFile_tree->Close();
+    };
 
     ///Declare the plots used in the analysis */
     virtual void DeclarePlots(void);
@@ -71,6 +78,56 @@ public:
 
     ///@return true if we requsted large bars in the xml */
     bool GetHasBig(void) { return requestedTypes_.find("big") != requestedTypes_.end(); }
+
+
+
+    /** \root TTree */
+    TFile* TFile_tree;
+    TTree* data_summary_tree;
+
+    unsigned int evtNumber=0;
+    std::string output_name = Globals::get()->GetOutputFileName();
+    std::string vandle_subtype = "";
+    double vandle_BarQDC=0;
+    double vandle_lQDC=0;
+    double vandle_rQDC=0;
+    double vandle_QDCPos=-500;
+    double vandle_TOF=0;
+    double vandle_lSnR=0;
+    double vandle_rSnR=0;
+    double vandle_lAmp=0;
+    double vandle_rAmp=0;
+    double vandle_lMaxAmpPos=0;
+    double vandle_rMaxAmpPos=0;
+    double vandle_lAveBaseline=0;
+    double vandle_rAveBaseline=0;
+    unsigned int vandle_barNum=0;
+    double vandle_TAvg=0;
+    double vandle_Corrected_TAvg=0;
+    double vandle_TDiff=0;
+    double vandle_Corrected_TDiff=0;
+    std::vector<unsigned int> vandle_ltrace;
+    std::vector<unsigned int> vandle_rtrace;
+
+    double beta_BarQDC=0;
+    double beta_lQDC=0;
+    double beta_rQDC=0;
+    double beta_lSnR=0;
+    double beta_rSnR=0;
+    double beta_lAmp=0;
+    double beta_rAmp=0;
+    double beta_lMaxAmpPos=0;
+    double beta_rMaxAmpPos=0;
+    double beta_lAveBaseline=0;
+    double beta_rAveBaseline=0;
+    unsigned int beta_barNum=0;
+    double beta_TAvg=0;
+    double beta_Corrected_TAvg=0;
+    double beta_TDiff=0;
+    double beta_Corrected_TDiff=0;
+    std::vector<unsigned int> beta_ltrace;
+    std::vector<unsigned int> beta_rtrace;
+
 
 private:
     ///Analyze the data for scenarios with Bar Starts; e.g. Double Beta detectors

--- a/Analysis/Utkscan/processors/include/VandleProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/VandleProcessor.hpp
@@ -17,9 +17,12 @@
 #include <set>
 #include <string>
 
+#ifdef useroot
 #include "TFile.h"
 #include "TTree.h"
 #include "TVector.h"
+
+#endif
 
 #include "BarDetector.hpp"
 #include "EventProcessor.hpp"
@@ -33,8 +36,10 @@ public:
 
     ///Default Destructor */
     ~VandleProcessor() {
+#ifdef useroot
         TFile_tree->Write();
         TFile_tree->Close();
+#endif
     };
 
     ///Declare the plots used in the analysis */
@@ -80,7 +85,7 @@ public:
     bool GetHasBig(void) { return requestedTypes_.find("big") != requestedTypes_.end(); }
 
 
-
+#ifdef useroot
     /** \root TTree */
     TFile* TFile_tree;
     TTree* data_summary_tree;
@@ -127,7 +132,7 @@ public:
     double beta_Corrected_TDiff=0;
     std::vector<unsigned int> beta_ltrace;
     std::vector<unsigned int> beta_rtrace;
-
+#endif
 
 private:
     ///Analyze the data for scenarios with Bar Starts; e.g. Double Beta detectors

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -51,7 +51,10 @@ VandleProcessor::VandleProcessor() : EventProcessor(OFFSET, RANGE, "VandleProces
 VandleProcessor::VandleProcessor(const std::vector<std::string> &typeList, const double &res, const double &offset,
                                  const unsigned int &numStarts, const double &compression/*=1.0*/) :
         EventProcessor(OFFSET,RANGE,"VandleProcessor") {
-    std::string treefilename = output_name + "_vandleTree.root";
+
+#ifdef useroot
+    std::string outputPath = Globals::get()->GetOutputPath();
+    std::string treefilename = outputPath + output_name + "_vandleTree.root";
     TFile_tree = new TFile(treefilename.c_str(),"recreate");
 
     data_summary_tree = new TTree("data_summary_tree","data_summary_tree");
@@ -99,6 +102,7 @@ VandleProcessor::VandleProcessor(const std::vector<std::string> &typeList, const
     data_summary_tree->Branch("beta_Corrected_TDiff",&beta_Corrected_TDiff);
     data_summary_tree->Branch("beta_ltrace",&beta_ltrace);
     data_summary_tree->Branch("beta_rtrace",&beta_rtrace);
+#endif
 
     associatedTypes.insert("vandle");
     plotMult_ = res;
@@ -204,6 +208,7 @@ void VandleProcessor::AnalyzeBarStarts(const BarDetector &bar, unsigned int &bar
             double tof = bar.GetCorTimeAve() - start.GetCorTimeAve() + bar.GetCalibration().GetTofOffset(startLoc);
             double corTof = CorrectTOF(tof, bar.GetFlightPath(), bar.GetCalibration().GetZ0());
 
+#ifdef useroot
             vandle_subtype=bar.GetType();
             vandle_lSnR=bar.GetLeftSide().GetTrace().GetSignalToNoiseRatio();
             vandle_rSnR=bar.GetRightSide().GetTrace().GetSignalToNoiseRatio();
@@ -247,7 +252,7 @@ void VandleProcessor::AnalyzeBarStarts(const BarDetector &bar, unsigned int &bar
             // printf("evtNumber:%d \n",evtNumber);
 
             data_summary_tree->Fill();
-
+#endif
             PlotTofHistograms(tof, corTof, bar.GetQdc(), barLoc * numStarts_ + startLoc, ReturnOffset(bar.GetType()));
         }
 }

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -240,8 +240,8 @@ void VandleProcessor::AnalyzeBarStarts(const BarDetector &bar, unsigned int &bar
             beta_lAveBaseline=start.GetLeftSide().GetAveBaseline();
             beta_rAveBaseline=start.GetRightSide().GetAveBaseline();
             beta_BarQDC=start.GetQdc();
-            beta_lQDC=bar.GetLeftSide().GetTraceQdc();
-            beta_rQDC=bar.GetRightSide().GetTraceQdc();
+            beta_lQDC=start.GetLeftSide().GetTraceQdc();
+            beta_rQDC=start.GetRightSide().GetTraceQdc();
             beta_barNum=startLoc;
             beta_TAvg=start.GetTimeAverage();
             beta_Corrected_TAvg=start.GetCorTimeAve();
@@ -268,6 +268,43 @@ void VandleProcessor::AnalyzeStarts(const BarDetector &bar, unsigned int &barLoc
             double tof = bar.GetCorTimeAve() - start.GetWalkCorrectedTime() + bar.GetCalibration().GetTofOffset(startLoc);
             double corTof = CorrectTOF(tof, bar.GetFlightPath(), bar.GetCalibration().GetZ0());
 
+#ifdef useroot
+            vandle_subtype=bar.GetType();
+            vandle_lSnR=bar.GetLeftSide().GetTrace().GetSignalToNoiseRatio();
+            vandle_rSnR=bar.GetRightSide().GetTrace().GetSignalToNoiseRatio();
+            vandle_lAmp=bar.GetLeftSide().GetMaximumValue();
+            vandle_rAmp=bar.GetRightSide().GetMaximumValue();
+            vandle_lMaxAmpPos=bar.GetLeftSide().GetMaximumPosition();
+            vandle_rMaxAmpPos=bar.GetRightSide().GetMaximumPosition();
+            vandle_lAveBaseline=bar.GetLeftSide().GetAveBaseline();
+            vandle_rAveBaseline=bar.GetRightSide().GetAveBaseline();
+            vandle_BarQDC=bar.GetQdc();
+            vandle_QDCPos=bar.GetQdcPosition();
+            vandle_lQDC=bar.GetLeftSide().GetTraceQdc();
+            vandle_rQDC=bar.GetRightSide().GetTraceQdc();
+            vandle_TOF=tof;
+            vandle_barNum=barLoc;
+            vandle_TAvg=bar.GetTimeAverage();
+            vandle_Corrected_TAvg=bar.GetCorTimeAve();
+            vandle_TDiff=bar.GetTimeDifference();
+            vandle_Corrected_TDiff=bar.GetCorTimeDiff();
+            vandle_ltrace=bar.GetLeftSide().GetTrace();
+            vandle_rtrace=bar.GetRightSide().GetTrace();
+
+            beta_lSnR=start.GetTrace().GetSignalToNoiseRatio();
+            beta_lAmp=start.GetMaximumValue();
+            beta_lMaxAmpPos=start.GetMaximumPosition();
+            beta_lAveBaseline=start.GetAveBaseline();
+            beta_lQDC=start.GetTraceQdc();
+            beta_TAvg=start.GetTime();
+            beta_Corrected_TAvg=start.GetWalkCorrectedTime();
+            beta_ltrace=start.GetTrace();
+
+            beta_barNum=startLoc;
+            // printf("evtNumber:%d \n",evtNumber);
+            data_summary_tree->Fill();
+
+#endif
             PlotTofHistograms(tof, corTof, bar.GetQdc(), barLoc * numStarts_ + startLoc, ReturnOffset(bar.GetType()));
         }
 }

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -51,6 +51,55 @@ VandleProcessor::VandleProcessor() : EventProcessor(OFFSET, RANGE, "VandleProces
 VandleProcessor::VandleProcessor(const std::vector<std::string> &typeList, const double &res, const double &offset,
                                  const unsigned int &numStarts, const double &compression/*=1.0*/) :
         EventProcessor(OFFSET,RANGE,"VandleProcessor") {
+    std::string treefilename = output_name + "_vandleTree.root";
+    TFile_tree = new TFile(treefilename.c_str(),"recreate");
+
+    data_summary_tree = new TTree("data_summary_tree","data_summary_tree");
+
+    data_summary_tree->Branch("evtNumber",&evtNumber);
+    data_summary_tree->Branch("output_name",&output_name);
+
+    data_summary_tree->Branch("vandle_subtype",&vandle_subtype);
+    data_summary_tree->Branch("vandle_BarQDC",&vandle_BarQDC);
+    data_summary_tree->Branch("vandle_lQDC",&vandle_lQDC);
+    data_summary_tree->Branch("vandle_rQDC",&vandle_rQDC);
+    data_summary_tree->Branch("vandle_QDCPos",&vandle_QDCPos);
+    data_summary_tree->Branch("vandle_TOF",&vandle_TOF);
+    data_summary_tree->Branch("vandle_lSnR",&vandle_lSnR);
+    data_summary_tree->Branch("vandle_rSnR",&vandle_rSnR);
+    data_summary_tree->Branch("vandle_lAmp",&vandle_lAmp);
+    data_summary_tree->Branch("vandle_rAmp",&vandle_rAmp);
+    data_summary_tree->Branch("vandle_lMaxAmpPos",&vandle_lMaxAmpPos);
+    data_summary_tree->Branch("vandle_rMaxAmpPos",&vandle_rMaxAmpPos);
+    data_summary_tree->Branch("vandle_lAveBaseline",&vandle_lAveBaseline);
+    data_summary_tree->Branch("vandle_rAveBaseline",&vandle_rAveBaseline);
+    data_summary_tree->Branch("vandle_barNum",&vandle_barNum);
+    data_summary_tree->Branch("vandle_TAvg",&vandle_TAvg);
+    data_summary_tree->Branch("vandle_Corrected_TAvg",&vandle_Corrected_TAvg);
+    data_summary_tree->Branch("vandle_TDiff",&vandle_TDiff);
+    data_summary_tree->Branch("vandle_Corrected_TDiff",&vandle_Corrected_TDiff);
+    data_summary_tree->Branch("vandle_ltrace",&vandle_ltrace);
+    data_summary_tree->Branch("vandle_rtrace",&vandle_rtrace);
+
+    data_summary_tree->Branch("beta_BarQDC",&beta_BarQDC);
+    data_summary_tree->Branch("beta_lQDC",&beta_lQDC);
+    data_summary_tree->Branch("beta_rQDC",&beta_rQDC);
+    data_summary_tree->Branch("beta_lSnR",&beta_lSnR);
+    data_summary_tree->Branch("beta_rSnR",&beta_rSnR);
+    data_summary_tree->Branch("beta_lAmp",&beta_lAmp);
+    data_summary_tree->Branch("beta_rAmp",&beta_rAmp);
+    data_summary_tree->Branch("beta_lMaxAmpPos",&beta_lMaxAmpPos);
+    data_summary_tree->Branch("beta_rMaxAmpPos",&beta_rMaxAmpPos);
+    data_summary_tree->Branch("beta_lAveBaseline",&vandle_lAveBaseline);
+    data_summary_tree->Branch("beta_rAveBaseline",&vandle_rAveBaseline);
+    data_summary_tree->Branch("beta_barNum",&beta_barNum);
+    data_summary_tree->Branch("beta_TAvg",&beta_TAvg);
+    data_summary_tree->Branch("beta_Corrected_TAvg",&beta_Corrected_TAvg);
+    data_summary_tree->Branch("beta_TDiff",&beta_TDiff);
+    data_summary_tree->Branch("beta_Corrected_TDiff",&beta_Corrected_TDiff);
+    data_summary_tree->Branch("beta_ltrace",&beta_ltrace);
+    data_summary_tree->Branch("beta_rtrace",&beta_rtrace);
+
     associatedTypes.insert("vandle");
     plotMult_ = res;
     plotOffset_ = offset;
@@ -152,9 +201,52 @@ void VandleProcessor::AnalyzeBarStarts(const BarDetector &bar, unsigned int &bar
         for (BarMap::iterator itStart = barStarts_.begin(); itStart != barStarts_.end(); itStart++) {
             unsigned int startLoc = (*itStart).first.first;
             BarDetector start = (*itStart).second;
-
             double tof = bar.GetCorTimeAve() - start.GetCorTimeAve() + bar.GetCalibration().GetTofOffset(startLoc);
             double corTof = CorrectTOF(tof, bar.GetFlightPath(), bar.GetCalibration().GetZ0());
+
+            vandle_subtype=bar.GetType();
+            vandle_lSnR=bar.GetLeftSide().GetTrace().GetSignalToNoiseRatio();
+            vandle_rSnR=bar.GetRightSide().GetTrace().GetSignalToNoiseRatio();
+            vandle_lAmp=bar.GetLeftSide().GetMaximumValue();
+            vandle_rAmp=bar.GetRightSide().GetMaximumValue();
+            vandle_lMaxAmpPos=bar.GetLeftSide().GetMaximumPosition();
+            vandle_rMaxAmpPos=bar.GetRightSide().GetMaximumPosition();
+            vandle_lAveBaseline=bar.GetLeftSide().GetAveBaseline();
+            vandle_rAveBaseline=bar.GetRightSide().GetAveBaseline();
+            vandle_BarQDC=bar.GetQdc();
+            vandle_QDCPos=bar.GetQdcPosition();
+            vandle_lQDC=bar.GetLeftSide().GetTraceQdc();
+            vandle_rQDC=bar.GetRightSide().GetTraceQdc();
+            vandle_TOF=tof;
+            vandle_barNum=barLoc;
+            vandle_TAvg=bar.GetTimeAverage();
+            vandle_Corrected_TAvg=bar.GetCorTimeAve();
+            vandle_TDiff=bar.GetTimeDifference();
+            vandle_Corrected_TDiff=bar.GetCorTimeDiff();
+            vandle_ltrace=bar.GetLeftSide().GetTrace();
+            vandle_rtrace=bar.GetRightSide().GetTrace();
+
+            beta_lSnR=start.GetLeftSide().GetTrace().GetSignalToNoiseRatio();
+            beta_rSnR=start.GetRightSide().GetTrace().GetSignalToNoiseRatio();
+            beta_lAmp=start.GetLeftSide().GetMaximumValue();
+            beta_rAmp=start.GetRightSide().GetMaximumValue();
+            beta_lMaxAmpPos=start.GetLeftSide().GetMaximumPosition();
+            beta_rMaxAmpPos=start.GetRightSide().GetMaximumPosition();
+            beta_lAveBaseline=start.GetLeftSide().GetAveBaseline();
+            beta_rAveBaseline=start.GetRightSide().GetAveBaseline();
+            beta_BarQDC=start.GetQdc();
+            beta_lQDC=bar.GetLeftSide().GetTraceQdc();
+            beta_rQDC=bar.GetRightSide().GetTraceQdc();
+            beta_barNum=startLoc;
+            beta_TAvg=start.GetTimeAverage();
+            beta_Corrected_TAvg=start.GetCorTimeAve();
+            beta_TDiff=start.GetTimeDifference();
+            beta_Corrected_TDiff=start.GetCorTimeDiff();
+            beta_ltrace=start.GetLeftSide().GetTrace();
+            beta_rtrace=start.GetRightSide().GetTrace();
+            // printf("evtNumber:%d \n",evtNumber);
+
+            data_summary_tree->Fill();
 
             PlotTofHistograms(tof, corTof, bar.GetQdc(), barLoc * numStarts_ + startLoc, ReturnOffset(bar.GetType()));
         }


### PR DESCRIPTION
This adds root output to the VandleProcessor. @jeremybundgaard added this pre #269, and i brought it up. The tree seems to work like we thought. I wrapped it in a #ifdef; this is probably the wrong way to guard against errors when you don't have root installed.

The change to the DetectorDriverXmlParser.cpp is something i discovered when i turned `PAASS_USE_ROOT` off. 