### PR TITLE
added methods to read external clock with pixie

### DIFF
--- a/Analysis/ScanLibraries/include/XiaData.hpp
+++ b/Analysis/ScanLibraries/include/XiaData.hpp
@@ -110,11 +110,16 @@ public:
 
     ///@return The upper 16 bits of the external time stamp provided to the
     /// module via the front panel
-    unsigned int GetExternalTimeHigh() const { return externalTimeHigh_; }
+    double GetExternalTimeHigh() const { return externalTimeHigh_; }
 
     ///@return The lower 32 bits of the external time stamp provided to the
     /// module via the front panel
     unsigned int GetExternalTimeLow() const { return externalTimeLow_; }
+
+    ///@return The external time stamp for the channel including all of the CFD information
+    /// when available.
+    double GetExternalTimeStamp() const { return externalTimeStamp_; }
+
 
     ///@return The unique ID of the channel.
     ///We can have a maximum of 208 channels in a crate, the first module (#0) is always in the second slot of the crate, and
@@ -185,6 +190,11 @@ public:
     ///@param[in] a : The value to set
     void SetExternalTimeLow(const unsigned int &a) { externalTimeLow_ = a; }
 
+    ///@brief Sets the external time stamp
+    ///@param[in] a : The value to set
+    void SetExternalTimeStamp(const double &a) { externalTimeStamp_ = a; }
+
+
     ///@brief Sets if we had a pileup found on-board
     ///@param[in] a : The value to set
     void SetPileup(const bool &a) { isPileup_ = a; }
@@ -231,6 +241,7 @@ private:
     double energy_; /// Raw pixie energy.
     double baseline_;///Baseline that was recorded with the energy sums
     double time_; ///< The time of arrival using all parts of the time
+    double externalTimeStamp_; ///< The time of arrival using all parts of the time
     double timeSansCfd_; ///< The time of arrival of the signal sans CFD time.
 
     unsigned int cfdTime_; /// CFD trigger time

--- a/Analysis/ScanLibraries/include/XiaListModeDataDecoder.hpp
+++ b/Analysis/ScanLibraries/include/XiaListModeDataDecoder.hpp
@@ -46,7 +46,15 @@ public:
     static double CalculateTimeInNs(
             const XiaListModeDataMask &mask, const XiaData &data);
 
-private:
+    ///Method to calculate the external time stamp as a double
+    ///@param[in] mask : The data mask containing the necessary information
+    /// to calculate the external time stamp.
+    ///@param[in] data : The data that we will use to calculate the external
+    /// that is provided (eg from BIGRIPS at RIKEN)
+    ///@return The calculated time in nanoseconds
+    static double CalculateExternalTimeStamp(const XiaData &data);
+
+    private:
     ///Method to decode word zero from the header.
     ///@param[in] word : The word that we need to decode
     ///@param[in] data : The XiaData object that we are going to fill.
@@ -56,12 +64,20 @@ private:
             const unsigned int &word, XiaData &data,
             const XiaListModeDataMask &mask);
 
-    ///Method to decode word two from the header.
+    ///Method to decode exxternal time stamp high (high = most signicant
+    ///16 bits of 48 bit time stamp) from data buffer.
     ///@param[in] word : The word that we need to decode
     ///@param[in] data : The XiaData object that we are going to fill.
     ///@param[in] mask : The data mask to decode the data
-    void DecodeWordTwo(const unsigned int &word, XiaData &data,
-                       const XiaListModeDataMask &mask);
+    unsigned int DecodeExternalTimeHigh(const unsigned int &word,
+      XiaData &data,const XiaListModeDataMask &mask);
+
+   ///Method to decode word two from the header.
+   ///@param[in] word : The word that we need to decode
+   ///@param[in] data : The XiaData object that we are going to fill.
+   ///@param[in] mask : The data mask to decode the data
+   void DecodeWordTwo(const unsigned int &word, XiaData &data,
+                      const XiaListModeDataMask &mask);
 
     ///Method to decode word three from the header.
     ///@param[in] word : The word that we need to decode

--- a/Analysis/ScanLibraries/include/XiaListModeDataMask.hpp
+++ b/Analysis/ScanLibraries/include/XiaListModeDataMask.hpp
@@ -88,6 +88,12 @@ public:
         return std::make_pair(0x0000FFFF, 0);
     }
 
+    ///Getter for the Mask and Shift of the External Time High.
+    ///@return The pair of the mask and bit shift to use to decode the data.
+    std::pair<unsigned int, unsigned int> GetExternalTimeHighMask() const {
+        return std::make_pair(0x0000FFFF, 0);
+    }
+
     ///Getter for the Mask and Shift of the Event Time High.
     ///@return The pair of the mask and bit shift to use to decode the data.
     std::pair<unsigned int, unsigned int> GetCfdFractionalTimeMask() const;


### PR DESCRIPTION
Added methods (DecodeExternalTimeHigh,CalculateExternalTimeStamp) to XiaListModeDataDecoder Class to read external time stamp scalars from .ldf buffers and store them as data members of XiaData. Added methods: (S,G)etExternalTimeStamp + members:double externalTimeStamp_ to the XiaData Class