### PR TITLE
Merge RIKEN2018 branch

### DIFF
--- a/Acquisition/Interface/include/PixieSupport.h
+++ b/Acquisition/Interface/include/PixieSupport.h
@@ -112,10 +112,10 @@ public:
 
     BitFlipper() {
         bit = 0;
-        num_toggle_bits = 19;
+        num_toggle_bits = 22;
     }
 
-    BitFlipper(unsigned int bit_, unsigned int num_toggle_bits_ = 19) {
+    BitFlipper(unsigned int bit_, unsigned int num_toggle_bits_ = 22) {
         bit = bit_;
         num_toggle_bits = num_toggle_bits_;
     }

--- a/Acquisition/Interface/source/PixieInterface.cpp
+++ b/Acquisition/Interface/source/PixieInterface.cpp
@@ -599,7 +599,7 @@ void PixieInterface::PrintSglChanPar(const char *name, int mod, int chan) {
     if (ReadSglChanPar(tmpName, val, mod, chan)) {
         cout.unsetf(ios_base::floatfield);
         cout << "  MOD " << setw(2) << mod << "  CHAN " << setw(2) << chan
-             << "  " << setw(15) << name << "  " << setprecision(6) << val
+             << "  " << setw(15) << name << "  " << setprecision(10) << val
              << endl;
     }
 }
@@ -612,7 +612,7 @@ void PixieInterface::PrintSglChanPar(const char *name, int mod, int chan,
     if (ReadSglChanPar(tmpName, val, mod, chan)) {
         cout.unsetf(ios_base::floatfield);
         cout << "  MOD " << setw(2) << mod << "  CHAN " << setw(2) << chan
-             << "  " << setw(15) << name << "  " << setprecision(6) << prev
+             << "  " << setw(15) << name << "  " << setprecision(10) << prev
              << " -> " << val << endl;
     }
 }

--- a/Acquisition/Interface/source/PixieSupport.cpp
+++ b/Acquisition/Interface/source/PixieSupport.cpp
@@ -64,15 +64,15 @@ const std::vector<std::string> BitFlipper::csr_txt({"Respond to group triggers o
 #else
 const std::vector<std::string> BitFlipper::toggle_names(
         {"", "", "good", "", "", "polarity", "", "", "trace", "QDC", "CFD",
-         "global", "raw", "trigger", "gain", "pileup", "catcher", "", "SHE"});
+         "global", "raw", "trigger", "gain", "pileup", "catcher", "", "SHE","","","ExtTime"});
 const std::vector<std::string> BitFlipper::csr_txt(
         {"", "", "Good Channel", "", "", "Trigger positive", "", "",
          "Enable trace capture", "Enable QDC sums capture",
          "Enable CFD trigger mode", "Enable global trigger validation",
          "Enable raw energy sums capture",
-         "Enable channel trigger validation", "HI/LO gain",
+         "Enable channel trigger validation", "LO/HI gain",
          "Pileup rejection control", "Hybrid bit", "",
-         "SHE single trace capture"});
+         "SHE single trace capture","","","External Timing"});
 #endif
 
 void BitFlipper::Help() {
@@ -80,15 +80,13 @@ void BitFlipper::Help() {
     for (unsigned int i = 0; i < num_toggle_bits; i++) {
         if (toggle_names[i] != "") {
             if (i < 10) {
-                std::cout << "  0" << i << " - " << toggle_names[i]
-                          << std::endl;
+                std::cout << "  0" << i << " - " << toggle_names[i] << std::endl;
             } else {
                 std::cout << "  " << i << " - " << toggle_names[i] << std::endl;
             }
         } else {
             if (i < 10) {
-                std::cout << "  0" << i << " - " << toggle_names[i]
-                          << std::endl;
+                std::cout << "  0" << i << " - " << toggle_names[i] << std::endl;
             } else {
                 std::cout << "  " << i << " - " << toggle_names[i] << std::endl;
             }
@@ -112,7 +110,7 @@ void BitFlipper::SetBit(std::string bit_) {
 }
 
 void BitFlipper::CSRAtest(unsigned int input_) {
-    Test(19, input_, csr_txt);
+    Test(22, input_, csr_txt);
 }
 
 bool BitFlipper::Test(unsigned int num_bits_, unsigned int input_,

--- a/Acquisition/Poll/source/poll2_core.cpp
+++ b/Acquisition/Poll/source/poll2_core.cpp
@@ -655,7 +655,7 @@ void Poll::help(){
     std::cout << "   pmwrite <mod> <param> <val>           - Write parameters to PIXIE modules\n";
     std::cout << "   adjust_offsets <module>               - Adjusts the baselines of a pixie module\n";
     std::cout << "   find_tau <module> <channel>           - Finds the decay constant for an active pixie channel\n";
-    std::cout << "   toggle <module> <channel> <bit>       - Toggle any of the 19 CHANNEL_CSRA bits for a pixie channel\n";
+    std::cout << "   toggle <module> <channel> <bit>       - Toggle any of the 22 CHANNEL_CSRA bits for a pixie channel\n";
     std::cout << "   toggle_bit <mod> <chan> <param> <bit> - Toggle any bit of any parameter of 32 bits or less\n";
     std::cout << "   csr_test <number>                     - Output the CSRA parameters for a given integer\n";
     std::cout << "   bit_test <num_bits> <number>          - Display active bits in a given integer up to 32 bits long\n";

--- a/Analysis/Resources/include/ChannelConfiguration.hpp
+++ b/Analysis/Resources/include/ChannelConfiguration.hpp
@@ -59,6 +59,9 @@ public:
     ///@return the value of the private variable subtype
     std::string GetSubtype() const { return subtype_; }
 
+    ///@return the value of the private variable group
+    std::string GetGroup() const { return group_; }
+
     ///@return Get the tag list
     std::set<std::string> GetTags() const { return tags_; }
 
@@ -109,6 +112,10 @@ public:
     /// Sets the pair of parameters that are needed for fitting analysis
     ///@param[in] a : The pair of parameters to set
     void SetFittingParameters(const std::pair<double, double> &a) { fittingParameters_ = a; }
+
+    /// Sets the Group string. Mainly used for the "addback" in the PostPaassProcessor ROOT code
+    ///@param[in] a : The Group string to set
+    void SetGroup(const std::string &a) { group_ = a; }
 
     ///Sets the location
     ///@param [in] a : sets the location for the channel
@@ -187,6 +194,7 @@ private:
     std::pair<double, double> fittingParameters_; ///< The parameters to use for the fitting routines
     unsigned int location_; ///< Specifies the real world location of the channel.
     std::string subtype_; ///< Specifies the detector sub type
+    std::string group_; ///<Specifies the detector group
     std::set<std::string> tags_; ///< A list of associated tags
     unsigned int traceDelayInSamples_; ///< The trace delay to help find the location of waveforms in traces
     TrapFilterParameters triggerFilterParameters_; ///< Parameters to use for trigger filter calculations

--- a/Analysis/ScanLibraries/include/XiaData.hpp
+++ b/Analysis/ScanLibraries/include/XiaData.hpp
@@ -110,7 +110,7 @@ public:
 
     ///@return The upper 16 bits of the external time stamp provided to the
     /// module via the front panel
-    double GetExternalTimeHigh() const { return externalTimeHigh_; }
+    unsigned int GetExternalTimeHigh() const { return externalTimeHigh_; }
 
     ///@return The lower 32 bits of the external time stamp provided to the
     /// module via the front panel
@@ -118,7 +118,7 @@ public:
 
     ///@return The external time stamp for the channel including all of the CFD information
     /// when available.
-    double GetExternalTimeStamp() const { return externalTimeStamp_; }
+    unsigned long long GetExternalTimeStamp() const { return externalTimeStamp_; }
 
 
     ///@return The unique ID of the channel.
@@ -192,7 +192,7 @@ public:
 
     ///@brief Sets the external time stamp
     ///@param[in] a : The value to set
-    void SetExternalTimeStamp(const double &a) { externalTimeStamp_ = a; }
+    void SetExternalTimeStamp(const unsigned long long &a) { externalTimeStamp_ = a; }
 
 
     ///@brief Sets if we had a pileup found on-board
@@ -241,7 +241,7 @@ private:
     double energy_; /// Raw pixie energy.
     double baseline_;///Baseline that was recorded with the energy sums
     double time_; ///< The time of arrival using all parts of the time
-    double externalTimeStamp_; ///< The time of arrival using all parts of the time
+    unsigned long long externalTimeStamp_; ///< The time of arrival using all parts of the time
     double timeSansCfd_; ///< The time of arrival of the signal sans CFD time.
 
     unsigned int cfdTime_; /// CFD trigger time

--- a/Analysis/ScanLibraries/include/XiaData.hpp
+++ b/Analysis/ScanLibraries/include/XiaData.hpp
@@ -110,11 +110,16 @@ public:
 
     ///@return The upper 16 bits of the external time stamp provided to the
     /// module via the front panel
-    unsigned int GetExternalTimeHigh() const { return externalTimeHigh_; }
+    double GetExternalTimeHigh() const { return externalTimeHigh_; }
 
     ///@return The lower 32 bits of the external time stamp provided to the
     /// module via the front panel
     unsigned int GetExternalTimeLow() const { return externalTimeLow_; }
+
+    ///@return The external time stamp for the channel including all of the CFD information
+    /// when available.
+    double GetExternalTimeStamp() const { return externalTimeStamp_; }
+
 
     ///@return The unique ID of the channel.
     ///We can have a maximum of 208 channels in a crate, the first module (#0) is always in the second slot of the crate, and
@@ -185,6 +190,11 @@ public:
     ///@param[in] a : The value to set
     void SetExternalTimeLow(const unsigned int &a) { externalTimeLow_ = a; }
 
+    ///@brief Sets the external time stamp
+    ///@param[in] a : The value to set
+    void SetExternalTimeStamp(const double &a) { externalTimeStamp_ = a; }
+
+
     ///@brief Sets if we had a pileup found on-board
     ///@param[in] a : The value to set
     void SetPileup(const bool &a) { isPileup_ = a; }
@@ -231,6 +241,7 @@ private:
     double energy_; /// Raw pixie energy.
     double baseline_;///Baseline that was recorded with the energy sums
     double time_; ///< The time of arrival using all parts of the time
+    double externalTimeStamp_; ///< The time of arrival using all parts of the time
     double timeSansCfd_; ///< The time of arrival of the signal sans CFD time.
 
     unsigned int cfdTime_; /// CFD trigger time

--- a/Analysis/ScanLibraries/include/XiaListModeDataDecoder.hpp
+++ b/Analysis/ScanLibraries/include/XiaListModeDataDecoder.hpp
@@ -52,7 +52,7 @@ public:
     ///@param[in] data : The data that we will use to calculate the external
     /// that is provided (eg from BIGRIPS at RIKEN)
     ///@return The calculated time in nanoseconds
-    static double CalculateExternalTimeStamp(const XiaData &data);
+    unsigned long long CalculateExternalTimeStamp(const XiaData &data);
 
     private:
     ///Method to decode word zero from the header.

--- a/Analysis/ScanLibraries/include/XiaListModeDataDecoder.hpp
+++ b/Analysis/ScanLibraries/include/XiaListModeDataDecoder.hpp
@@ -46,7 +46,15 @@ public:
     static double CalculateTimeInNs(
             const XiaListModeDataMask &mask, const XiaData &data);
 
-private:
+    ///Method to calculate the external time stamp as a double
+    ///@param[in] mask : The data mask containing the necessary information
+    /// to calculate the external time stamp.
+    ///@param[in] data : The data that we will use to calculate the external
+    /// that is provided (eg from BIGRIPS at RIKEN)
+    ///@return The calculated time in nanoseconds
+    static double CalculateExternalTimeStamp(const XiaData &data);
+
+    private:
     ///Method to decode word zero from the header.
     ///@param[in] word : The word that we need to decode
     ///@param[in] data : The XiaData object that we are going to fill.
@@ -56,12 +64,20 @@ private:
             const unsigned int &word, XiaData &data,
             const XiaListModeDataMask &mask);
 
-    ///Method to decode word two from the header.
+    ///Method to decode exxternal time stamp high (high = most signicant
+    ///16 bits of 48 bit time stamp) from data buffer.
     ///@param[in] word : The word that we need to decode
     ///@param[in] data : The XiaData object that we are going to fill.
     ///@param[in] mask : The data mask to decode the data
-    void DecodeWordTwo(const unsigned int &word, XiaData &data,
-                       const XiaListModeDataMask &mask);
+    unsigned int DecodeExternalTimeHigh(const unsigned int &word,
+      XiaData &data,const XiaListModeDataMask &mask);
+
+   ///Method to decode word two from the header.
+   ///@param[in] word : The word that we need to decode
+   ///@param[in] data : The XiaData object that we are going to fill.
+   ///@param[in] mask : The data mask to decode the data
+   void DecodeWordTwo(const unsigned int &word, XiaData &data,
+                      const XiaListModeDataMask &mask);
 
     ///Method to decode word three from the header.
     ///@param[in] word : The word that we need to decode

--- a/Analysis/ScanLibraries/include/XiaListModeDataMask.hpp
+++ b/Analysis/ScanLibraries/include/XiaListModeDataMask.hpp
@@ -88,6 +88,12 @@ public:
         return std::make_pair(0x0000FFFF, 0);
     }
 
+    ///Getter for the Mask and Shift of the External Time High.
+    ///@return The pair of the mask and bit shift to use to decode the data.
+    std::pair<unsigned int, unsigned int> GetExternalTimeHighMask() const {
+        return std::make_pair(0x0000FFFF, 0);
+    }
+
     ///Getter for the Mask and Shift of the Event Time High.
     ///@return The pair of the mask and bit shift to use to decode the data.
     std::pair<unsigned int, unsigned int> GetCfdFractionalTimeMask() const;

--- a/Analysis/ScanLibraries/source/XiaListModeDataDecoder.cpp
+++ b/Analysis/ScanLibraries/source/XiaListModeDataDecoder.cpp
@@ -121,15 +121,15 @@ vector<XiaData *> XiaListModeDataDecoder::DecodeBuffer(unsigned int *buf, const 
           //// **** for troubleshooting **** ////
           // cout<<"hasEnergySums "<< hasEnergySums<<'\t';
           // if(buf[4]>20)continue;
-          cout<<" hasExternalTimestamp="<< hasExternalTimestamp<<'\t';
+          //cout<<" hasExternalTimestamp="<< hasExternalTimestamp<<'\t';
           // cout<<"hasQdc "<< hasQdc<<'\t';
-          for (unsigned int i = 0; i < headerLength; i++) {
-            cout<<"buf["<<i<<"]="<<hex<<buf[i]<<'\t';
-          }cout<<endl;
+          //for (unsigned int i = 0; i < headerLength; i++) {
+          //  cout<<"buf["<<i<<"]="<<hex<<buf[i]<<'\t';
+          //}cout<<endl;
           // cout<<"data->GetExternalTimeHigh()="<<data->GetExternalTimeHigh()<<'\t';
           // cout<<"data->GetExternalTimeLow()="<<data->GetExternalTimeLow()<<'\t';
-          cout.precision(20);
-	  cout<<"data->GetExternalTimeStamp()="<<data->GetExternalTimeStamp()<<endl;
+          //cout.precision(20);
+	  //cout<<"data->GetExternalTimeStamp()="<<data->GetExternalTimeStamp()<<endl;
 
         }
 

--- a/Analysis/ScanLibraries/source/XiaListModeDataDecoder.cpp
+++ b/Analysis/ScanLibraries/source/XiaListModeDataDecoder.cpp
@@ -112,9 +112,9 @@ vector<XiaData *> XiaListModeDataDecoder::DecodeBuffer(unsigned int *buf, const 
 
         if (hasExternalTimestamp) {
           /// set least significant 32 bits of 48 bit external time stamp
-          data->SetExternalTimeLow(headerLength-1);
+          data->SetExternalTimeLow(buf[4]);
           /// set most significant 16 bits of 48 bit external time stamp
-          data->SetExternalTimeHigh(DecodeExternalTimeHigh(headerLength, *data, mask));
+          data->SetExternalTimeHigh(DecodeExternalTimeHigh(buf[5], *data, mask));
           /// stores 48 bit external time stamp as an XiaData member -> double externalTimeStamp_
           data->SetExternalTimeStamp(CalculateExternalTimeStamp(*data));
 
@@ -128,7 +128,8 @@ vector<XiaData *> XiaListModeDataDecoder::DecodeBuffer(unsigned int *buf, const 
           }cout<<endl;
           // cout<<"data->GetExternalTimeHigh()="<<data->GetExternalTimeHigh()<<'\t';
           // cout<<"data->GetExternalTimeLow()="<<data->GetExternalTimeLow()<<'\t';
-          // cout<<"data->GetExternalTimeStamp()="<<data->GetExternalTimeStamp()<<endl;
+          cout.precision(20);
+	  cout<<"data->GetExternalTimeStamp()="<<data->GetExternalTimeStamp()<<endl;
 
         }
 

--- a/Analysis/Utkscan/CMakeLists.txt
+++ b/Analysis/Utkscan/CMakeLists.txt
@@ -4,7 +4,7 @@ if (NOT PAASS_USE_GSL)
 endif (NOT PAASS_USE_GSL)
 
 #CMake file for UTKScan.
-option(PAASS_UTKSCAN_GAMMA_GATES "Gamma-Gamma gates in GeProcessor" OFF)
+option(PAASS_UTKSCAN_GAMMA_GATES "Gamma-Gamma gates in the Gamma-Ray Processors" OFF)
 option(PAASS_UTKSCAN_ONLINE "Options for online scans" OFF)
 option(PAASS_UTKSCAN_TREE_DEBUG "Debugging info for TreeCorrelator" OFF)
 option(PAASS_UTKSCAN_VERBOSE "Make Scan More Verbose" OFF)
@@ -13,7 +13,7 @@ option(PAASS_UTKSCAN_VERBOSE "Make Scan More Verbose" OFF)
 # structure change on 03/20/08. Is is REQUIRED!!
 add_definitions(-D newreadout)
 
-#utkscan will have Gamma-Gamma gating in the GeProcessor
+#utkscan will have Gamma-Gamma gating in the CloverProcessor and GammaScintProcessor
 if (PAASS_UTKSCAN_GAMMA_GATES)
     add_definitions(-D GGATES)
 endif (PAASS_UTKSCAN_GAMMA_GATES)
@@ -41,6 +41,18 @@ add_subdirectory(core)
 add_subdirectory(experiment)
 add_subdirectory(processors)
 
+#added by T.T. King for Vector Root Libs
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+SET(CMAKE_SKIP_INSTALL_RPATH FALSE)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+ROOT_GENERATE_DICTIONARY(SysRootStruc ProcessorRootStruc.hpp LINKDEF processors/include/SysRootLinkDef.hpp )
+add_library(SysRootStrucLib SHARED SysRootStruc.cxx SysRootStruc)
+
+#End T.T. King Additions
 #------------------------------------------------------------------------------
 
 if (NOT PAASS_USE_HRIBF)
@@ -50,7 +62,8 @@ if (NOT PAASS_USE_HRIBF)
             $<TARGET_OBJECTS:UtkscanCoreObjects>
             $<TARGET_OBJECTS:UtkscanAnalyzerObjects>
             $<TARGET_OBJECTS:UtkscanProcessorObjects>
-            $<TARGET_OBJECTS:UtkscanExperimentObjects>)
+            $<TARGET_OBJECTS:UtkscanExperimentObjects>
+            SysRootStruc.cxx)
 else (PAASS_USE_HRIBF)
     set(SCAN_NAME utkscanor)
     add_executable(${SCAN_NAME}
@@ -63,17 +76,25 @@ else (PAASS_USE_HRIBF)
     target_link_libraries(utkscanor ${HRIBF_LIBRARIES})
 endif (NOT PAASS_USE_HRIBF)
 
-target_link_libraries(${SCAN_NAME} ${LIBS} PaassScanStatic ResourceStatic PaassCoreStatic PugixmlStatic PaassResourceStatic)
+target_link_libraries(${SCAN_NAME} ${LIBS} SysRootStrucLib PaassScanStatic ResourceStatic PaassCoreStatic PugixmlStatic PaassResourceStatic )
 
 if (PAASS_USE_GSL)
     target_link_libraries(${SCAN_NAME} ${GSL_LIBRARIES})
 endif (PAASS_USE_GSL)
 
 if (PAASS_USE_ROOT)
-    target_link_libraries(${SCAN_NAME} ${ROOT_LIBRARIES})
+    target_link_libraries(${SCAN_NAME} ${ROOT_LIBRARIES} SysRootStrucLib)
 endif (PAASS_USE_ROOT)
 
 #------------------------------------------------------------------------------
 
 install(TARGETS ${SCAN_NAME} DESTINATION bin)
 install(DIRECTORY share/utkscan DESTINATION share)
+install(TARGETS SysRootStrucLib DESTINATION lib)
+
+install(FILES ${CMAKE_SOURCE_DIR}/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp DESTINATION include/)
+install(FILES ${CMAKE_SOURCE_DIR}/Analysis/Utkscan/processors/include/GSaddback.hpp DESTINATION include/)
+#Install the ROOT 6 PCM.
+if (${ROOT_VERSION} VERSION_GREATER "6.0")
+    install( FILES ${CMAKE_CURRENT_BINARY_DIR}/SysRootStruc_rdict.pcm DESTINATION lib/)
+endif (${ROOT_VERSION} VERSION_GREATER "6.0")

--- a/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
@@ -26,8 +26,8 @@ WaveformAnalyzer::WaveformAnalyzer(const std::set<std::string> &ignoredTypes)
 
 void WaveformAnalyzer::Analyze(Trace &trace, const ChannelConfiguration &cfg) {
     TraceAnalyzer::Analyze(trace, cfg);
+    if (trace.IsSaturated() || trace.empty() || ignoredTypes_.find(cfg.GetType()) != ignoredTypes_.end() || ignoredTypes_.find(cfg.GetType()+":"+cfg.GetSubtype()) != ignoredTypes_.end()) {
 
-    if (trace.IsSaturated() || trace.empty() || ignoredTypes_.find(cfg.GetType()) != ignoredTypes_.end()) {
         trace.SetHasValidAnalysis(false);
         EndAnalyze();
         return;

--- a/Analysis/Utkscan/core/include/DammPlotIds.hpp
+++ b/Analysis/Utkscan/core/include/DammPlotIds.hpp
@@ -105,6 +105,12 @@ namespace dammIds {
         const int RANGE = 499;//!< Range for CloverProcessor
     }
 
+    ///in CloverFragProcessor.cpp
+    namespace cloverFrag {
+        const int OFFSET = 2500;//!< Offset for CloverFragProcessor
+        const int RANGE = 499;//!< Range for CloverFragProcessor
+    }
+
     ///in GeProcessor.hpp
     namespace ge {
         const int OFFSET = 2999;//!< Offset for GeProcessor

--- a/Analysis/Utkscan/core/include/DammPlotIds.hpp
+++ b/Analysis/Utkscan/core/include/DammPlotIds.hpp
@@ -46,6 +46,7 @@ namespace dammIds {
         const int D_NUMBER_OF_EVENTS = 1811;//!< Number of processed events
         const int D_HAS_TRACE = 1812;//!< Plot for Channels w/ Traces
         const int D_INTERNAL_TS_CHECK = 1813;//!< Plot of time difference between the 2 external time stamps
+        const int DD_TRACE_MAX = 1814;//!< Plot for Max Value in Trace
     }
 
     /// in PspmtProcessor.cpp

--- a/Analysis/Utkscan/core/include/DammPlotIds.hpp
+++ b/Analysis/Utkscan/core/include/DammPlotIds.hpp
@@ -45,6 +45,7 @@ namespace dammIds {
         const int DD_RUNTIME_MSEC = 1810;//!< Run Time in ms
         const int D_NUMBER_OF_EVENTS = 1811;//!< Number of processed events
         const int D_HAS_TRACE = 1812;//!< Plot for Channels w/ Traces
+        const int D_INTERNAL_TS_CHECK = 1813;//!< Plot of time difference between the 2 external time stamps
     }
 
     /// in PspmtProcessor.cpp

--- a/Analysis/Utkscan/core/include/DammPlotIds.hpp
+++ b/Analysis/Utkscan/core/include/DammPlotIds.hpp
@@ -94,7 +94,11 @@ namespace dammIds {
         const int OFFSET = 2200;//!< Offset for Hen3Processor
         const int RANGE = 50;//!< Range for Hen3Processor
     }
-
+    ///in GammaScintProcessor.cpp
+    namespace gscint {
+        const int OFFSET = 2300;//!< Offset for GammaScintProcessor
+        const int RANGE = 200;//!< Range for GammaScintProcessor
+    }
     ///in CloverProcessor.cpp
     namespace clover {
         const int OFFSET = 2500;//!< Offset for CloverProcessor

--- a/Analysis/Utkscan/core/include/DetectorDriver.hpp
+++ b/Analysis/Utkscan/core/include/DetectorDriver.hpp
@@ -60,7 +60,7 @@
 #include "CloverProcessor.hpp"
 #include "GammaScintProcessor.hpp"
 #include "VandleProcessor.hpp"
-#include "ProcessorStruc.hpp"
+#include "ProcessorRootStruc.hpp"
 
 #endif
 

--- a/Analysis/Utkscan/core/include/DetectorDriver.hpp
+++ b/Analysis/Utkscan/core/include/DetectorDriver.hpp
@@ -253,6 +253,7 @@ private:
     std::vector<CLOVERS> Csing;
     std::vector<GAMMASCINT> GSsing;
     std::vector<VANDLES> Vandles;
+    unsigned long long externalTS = 0; //!< External TimeStamp, it is filled to the root tree as the LAST one in the pixie event. because we cant guarantee that we will get a new TimeStamp for every pixie event, we do not reset it, ever.
 
     bool sysrootbool_;
     double rFileSizeGB_;

--- a/Analysis/Utkscan/core/include/DetectorDriver.hpp
+++ b/Analysis/Utkscan/core/include/DetectorDriver.hpp
@@ -185,6 +185,8 @@ public:
      * */
     std::set<std::string> GetProcessorList();
 
+    /**\return System ROOT Output Status. True if ROOT output is requested */
+    bool GetSysRootOutput(){ return sysrootbool_; }
 
     /** \return the set of detectors used in the analysis */
     const std::set<std::string> &GetUsedDetectors(void) const;
@@ -204,7 +206,6 @@ public:
     /** Default Destructor */
     virtual ~DetectorDriver();
 
-    bool GetSysRootOutput(){ return sysrootbool_; }
 
 private:
     /** Constructor that initializes the various processors and analyzers. */
@@ -242,7 +243,10 @@ private:
                                     const char *title) {
         histo.DeclareHistogram2D(dammId, xSize, ySize, title);
     }
-
+    /*! \brief Fills the Logic structure for ROOT output.
+     * Because the logic spans pixie events if we fill in the processor it does not get filled into each ROOT entry.
+     * So we will fill here in the DetectorDriver utilizing the work that was put into the TreeCorrelator  */
+    void FillLogicStruc();
 
     std::set<std::string> setProcess; /**< list of processors used in the analysis.
     * This should be identical to vecProcess, but in string form */
@@ -253,8 +257,12 @@ private:
 
     PixTreeEvent pixie_tree_event_; /** tree event container class **/
 
-    bool sysrootbool_;
-    double rFileSizeGB_;
+    bool sysrootbool_; ///Bool for ROOT ouput
+    bool fillLogic_; /// Should we fill the logic struct
+    processor_struct::LOGIC LogStruc; //Logic root struc
+    int tapeCycleNum_; //counts the number of tape cycles
+    double lastCycleTime_; // last cycle start time (for cycle num incrementing)
+    double rFileSizeGB_;/// Max size in GB for the ROOT file before starting a new one
 };
 
 #endif // __DETECTORDRIVER_HPP_

--- a/Analysis/Utkscan/core/include/DetectorDriver.hpp
+++ b/Analysis/Utkscan/core/include/DetectorDriver.hpp
@@ -251,11 +251,7 @@ private:
     TTree *PTree;
     TBranch *PBr;
 
-    std::vector<CLOVERS> Csing;
-    std::vector<GAMMASCINT> GSsing;
-    std::vector<VANDLES> Vandles;
-    std::vector<PSPMT> PSPMTvec;
-    unsigned long long externalTS = 0; //!< External TimeStamp, it is filled to the root tree as the LAST one in the pixie event. because we cant guarantee that we will get a new TimeStamp for every pixie event, we do not reset it, ever.
+    PixTreeEvent pixie_tree_event_; /** tree event container class **/
 
     bool sysrootbool_;
     double rFileSizeGB_;

--- a/Analysis/Utkscan/core/include/DetectorDriver.hpp
+++ b/Analysis/Utkscan/core/include/DetectorDriver.hpp
@@ -61,6 +61,7 @@
 #include "GammaScintProcessor.hpp"
 #include "VandleProcessor.hpp"
 #include "ProcessorRootStruc.hpp"
+#include "PspmtProcessor.hpp"
 
 #endif
 
@@ -253,6 +254,7 @@ private:
     std::vector<CLOVERS> Csing;
     std::vector<GAMMASCINT> GSsing;
     std::vector<VANDLES> Vandles;
+    std::vector<PSPMT> PSPMTvec;
     unsigned long long externalTS = 0; //!< External TimeStamp, it is filled to the root tree as the LAST one in the pixie event. because we cant guarantee that we will get a new TimeStamp for every pixie event, we do not reset it, ever.
 
     bool sysrootbool_;

--- a/Analysis/Utkscan/core/include/DetectorDriverXmlParser.hpp
+++ b/Analysis/Utkscan/core/include/DetectorDriverXmlParser.hpp
@@ -29,6 +29,12 @@ public:
     ///@throw invalid_argument if the node cannot be found.
     void ParseNode(DetectorDriver *driver);
 
+    ///Returns the config option to have Detector Driver root output
+    std::pair<bool,std::string> GetRootOutOpt(){ return SysRootOut;}
+
+    ///Returns the Max Root Tree File size (In GB)
+    double GetRFileSize(){return rFileSize; }
+
 private:
     ///An instance of the messenger class so that we can output pretty info
     Messenger messenger_;
@@ -49,6 +55,11 @@ private:
     ///Prints all of the attributes for a node to the screen.
     ///@param[in] node : The node that we'd like to print the attirbutes for.
     void PrintAttributeMessage(pugi::xml_node &node);
+
+    ///Controls whether or not to have system-wide root output from the Detector Driver.
+    std::pair<bool,std::string> SysRootOut;
+
+    double rFileSize;//!<Root File's roll over size.
 };
 
 #endif //PAASS_DETECTORDRIVERXMLPARSER_HPP

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -251,7 +251,7 @@ void DetectorDriver::DeclarePlots() {
             DetectorLibrary *modChan = DetectorLibrary::get();
             DeclareHistogram1D(D_NUMBER_OF_EVENTS, S4, "event counter");
             DeclareHistogram1D(D_HAS_TRACE, S8, "channels with traces");
-            DeclareHistogram2D(DD_TRACE_MAX,S8, SD, "Max Value in Trace vs Chan Num");
+            DeclareHistogram2D(DD_TRACE_MAX,SD, S8, "Max Value in Trace vs Chan Num");
             DeclareHistogram1D(D_SUBEVENT_GAP, SE, "Time Between Channels in 10 ns / bin");
             DeclareHistogram1D(D_EVENT_LENGTH, SE, "Event Length in ns");
             DeclareHistogram1D(D_EVENT_GAP, SE, "Time Between Events in ns");

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -251,6 +251,7 @@ void DetectorDriver::DeclarePlots() {
             DetectorLibrary *modChan = DetectorLibrary::get();
             DeclareHistogram1D(D_NUMBER_OF_EVENTS, S4, "event counter");
             DeclareHistogram1D(D_HAS_TRACE, S8, "channels with traces");
+            DeclareHistogram2D(DD_TRACE_MAX,S8, SD, "Max Value in Trace vs Chan Num");
             DeclareHistogram1D(D_SUBEVENT_GAP, SE, "Time Between Channels in 10 ns / bin");
             DeclareHistogram1D(D_EVENT_LENGTH, SE, "Event Length in ns");
             DeclareHistogram1D(D_EVENT_GAP, SE, "Time Between Events in ns");
@@ -326,6 +327,9 @@ int DetectorDriver::ThreshAndCal(ChanEvent *chan, RawEvent &rawev) {
         //Saves the time in nanoseconds
         chan->SetHighResTime((trace.GetPhase() * Globals::get()->GetAdcClockInSeconds() +
                 chan->GetTimeSansCfd() * Globals::get()->GetFilterClockInSeconds()) * 1e9);
+
+        //Plot max Value in trace post trace analysis
+        plot(DD_TRACE_MAX,trace.GetMaxInfo().second,id);
     } else {
         /// otherwise, use the Pixie on-board calculated energy and high res
         /// time is zero.

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -11,6 +11,7 @@
 #include <limits>
 #include <map>
 #include <sstream>
+#include <PspmtProcessor.hpp>
 
 #include "DammPlotIds.hpp"
 #include "DetectorDriver.hpp"
@@ -116,6 +117,13 @@ DetectorDriver::DetectorDriver() : histo(OFFSET, RANGE, "DetectorDriver") {
                 PTree->Branch("Vandles", &Vandles);
             } else if ((*itp) == "CloverProcessor") {
                 PTree->Branch("Clover",&Csing);
+            } else if ((*itp) == "PspmtProcessor"){
+                PTree->Branch("PSPMT",&PSPMTvec);
+                auto PSPMTheader = ((PspmtProcessor *) GetProcessor("PspmtProcessor"))->GetPSPMTHeader();
+                TNamed VDType("VDType",PSPMTheader.first);
+                VDType.Write();
+                TNamed Thresh("SoftThresh",PSPMTheader.second);
+                Thresh.Write();
             } else{
                 continue;
             }
@@ -167,6 +175,8 @@ void DetectorDriver::ProcessEvent(RawEvent &rawev) {
                 Vandles.clear();
             } else if ((*itp) == "CloverProcessor") {
                 Csing.clear();
+            } else if ((*itp) == "PspmtProcessor"){
+              PSPMTvec.clear();
             } else{
                 continue;
             }
@@ -237,6 +247,8 @@ void DetectorDriver::ProcessEvent(RawEvent &rawev) {
                 Vandles = ((VandleProcessor *) get()->GetProcessor("VandleProcessor"))->GetVanVector();
             } else if ((*itp) == "CloverProcessor"){
                 Csing = ((CloverProcessor * ) get()->GetProcessor("CloverProcessor"))->GetCloverVec();
+            } else if ((*itp) == "PspmtProcessor"){
+                PSPMTvec = ((PspmtProcessor *) get()->GetProcessor("PspmtProcessor"))->GetPSPMTvector();
             } else{
                 continue;
             }

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -224,10 +224,13 @@ void DetectorDriver::ProcessEvent(RawEvent &rawev) {
         cout << Display::WarningStr("Warning caught at DetectorDriver::ProcessEvent") << endl;
         cout << "\t" << Display::WarningStr(w.what()) << endl;
     }
-    eventNumber_++;
     if (sysrootbool_) {
+        pixie_tree_event_.eventNum = eventNumber_;
+        pixie_tree_event_.fileName = Globals::get()->GetOutputFileName());
         PTree->Fill();
     }
+    eventNumber_++;
+
 }
 /// Declare some of the raw and basic plots that are going to be used in the
 /// analysis of the data. These include raw and calibrated energy spectra,

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -226,7 +226,7 @@ void DetectorDriver::ProcessEvent(RawEvent &rawev) {
     }
     if (sysrootbool_) {
         pixie_tree_event_.eventNum = eventNumber_;
-        pixie_tree_event_.fileName = Globals::get()->GetOutputFileName());
+        pixie_tree_event_.fileName = Globals::get()->GetOutputFileName();
         PTree->Fill();
     }
     eventNumber_++;

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -64,7 +64,8 @@ DetectorDriver::DetectorDriver() : histo(OFFSET, RANGE, "DetectorDriver") {
             setProcess.emplace((*it)->GetName());
         }
         if (setProcess.empty()){
-            GeneralException("Exception:DetectorDriver:: setProcess is empty and root requested. this will cause segfaults on root fill()");
+            throw GeneralException("Exception:DetectorDriver:: setProcess is empty and root requested. this will cause segfaults on root fill()");
+
         }
 
         Long64_t rFileSizeB_ = rFileSizeGB_ * pow(1000,3);
@@ -89,6 +90,9 @@ DetectorDriver::DetectorDriver() : histo(OFFSET, RANGE, "DetectorDriver") {
         createTnamed.Write();
         RootversionTnamed.Write();
         outRootTNamed.Write();
+
+        //write the external TS to
+        PTree->Branch("ExternalTS",&externalTS);
 
         for (auto itp = setProcess.begin(); itp !=setProcess.end();itp++) {
 
@@ -192,6 +196,9 @@ void DetectorDriver::ProcessEvent(RawEvent &rawev) {
             if (innerEvtCounter == 0){
                 eventFirstTime_= (*it)->GetTimeSansCfd(); //sets the time of the first det event in the pixie event
             }
+            if ((*it)->GetChanID().HasTag("ets"))
+                externalTS = (*it)->GetExternalTimeStamp();
+
             innerEvtCounter++;
         }
         if ( eventNumber_ == 0){

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -25,6 +25,7 @@
 #include "RawEvent.hpp"
 #include "TraceAnalyzer.hpp"
 #include "TreeCorrelator.hpp"
+#include "../../../../install/include/ProcessorRootStruc.hpp"
 
 using namespace std;
 using namespace dammIds::raw;
@@ -186,12 +187,20 @@ void DetectorDriver::ProcessEvent(RawEvent &rawev) {
 
             EventData data(time, energy, location);
             TreeCorrelator::get()->place(place)->activate(data);
-            if (innerEvtCounter == 0){
-                eventFirstTime_= (*it)->GetTimeSansCfd(); //sets the time of the first det event in the pixie event
+            if (innerEvtCounter == 0) {
+                eventFirstTime_ = (*it)->GetTimeSansCfd(); //sets the time of the first det event in the pixie event
             }
-            if ((*it)->GetChanID().HasTag("ets"))
-                pixie_tree_event_.externalTS = (*it)->GetExternalTimeStamp();
-
+            if ((*it)->GetChanID().HasTag("ets1")) {
+                pixie_tree_event_.externalTS1 = (*it)->GetExternalTimeStamp();
+            }
+            if ((*it)->GetChanID().HasTag("ets2")){
+                pixie_tree_event_.externalTS2 = (*it)->GetExternalTimeStamp();
+            }
+            if(pixie_tree_event_.externalTS2 != 0 && pixie_tree_event_.externalTS1 !=0 ) {
+                plot(D_INTERNAL_TS_CHECK, ((pixie_tree_event_.externalTS1 - pixie_tree_event_.externalTS2) + 1000));
+            }else {
+                plot(D_INTERNAL_TS_CHECK,100);
+            }
             innerEvtCounter++;
         }
         if ( eventNumber_ == 0){
@@ -236,6 +245,7 @@ void DetectorDriver::DeclarePlots() {
         DeclareHistogram1D(D_HIT_SPECTRUM, S7, "channel hit spectrum");
         DeclareHistogram2D(DD_RUNTIME_SEC, SE, S6, "run time - s");
         DeclareHistogram2D(DD_RUNTIME_MSEC, SE, S7, "run time - ms");
+        DeclareHistogram1D(D_INTERNAL_TS_CHECK, SB,"Time Diff between ETS1 and ES2 +1000. 100=BAD");
 
         if (Globals::get()->HasRawHistogramsDefined()) {
             DetectorLibrary *modChan = DetectorLibrary::get();

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -25,7 +25,7 @@
 #include "RawEvent.hpp"
 #include "TraceAnalyzer.hpp"
 #include "TreeCorrelator.hpp"
-#include "../../../../install/include/ProcessorRootStruc.hpp"
+#include "ProcessorRootStruc.hpp"
 
 using namespace std;
 using namespace dammIds::raw;

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -105,14 +105,8 @@ DetectorDriver::DetectorDriver() : histo(OFFSET, RANGE, "DetectorDriver") {
                 auto GSheader = ((GammaScintProcessor *) GetProcessor("GammaScintProcessor"))->GetTHeader();
                 TNamed faciTnamed("facilityType", GSheader.find("FacilityType")->second);
                 TNamed bunchTnamed("bunchingTime(sec)", GSheader.find("BunchingTime")->second);
-                //including a reminder for which str gscint subtypes map to which num subtype
-                //general order is decreasing mass/weight (-1 is the default/Unknown match)
-                std::stringstream type2NumType;
-                type2NumType << "nai=0 " << " bighag=1 " << " smallhag=2 ";
-                TNamed typesTNamed("GS_type->NumType", type2NumType.str().c_str());
                 faciTnamed.Write();
                 bunchTnamed.Write();
-                typesTNamed.Write();
 
             } else if ((*itp) == "PspmtProcessor"){
                 auto PSPMTheader = ((PspmtProcessor *) GetProcessor("PspmtProcessor"))->GetPSPMTHeader();

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -137,7 +137,7 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
             std::string defaultThreshold = "10.";
             std::string defaultBunch = "30.";
 
-            GScintArgs.insert(make_pair("DDroot",SysRootOut.second ));
+            GScintArgs.insert(make_pair("DDroot",processor.attribute("groot").as_string(SysRootOut.second.c_str())));
             GScintArgs.insert(make_pair("BunchingTime", processor.attribute("BunchingTime").as_string(defaultBunch.c_str())));
             GScintArgs.insert(make_pair("EnergyVsTime",processor.attribute("EvsT").as_string("true")));
             GScintArgs.insert(make_pair("MRBWin",processor.attribute("MRBWin").as_string(defaultSubEvtWin.c_str())));

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -192,7 +192,8 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
                     processor.attribute("yso_threshold").as_double(50.0),
                     processor.attribute("front_scale").as_double(500.0),
                     processor.attribute("front_offset").as_double(500.0),
-                    processor.attribute("front_threshold").as_double(50.0)
+                    processor.attribute("front_threshold").as_double(50.0),
+                    processor.attribute("rotation").as_double(0.0)
             ));
         } else if (name == "TeenyVandleProcessor") {
             vecProcess.push_back(new TeenyVandleProcessor());

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -26,6 +26,7 @@
 #include "BetaScintProcessor.hpp"
 #include "CloverCalibProcessor.hpp"
 #include "CloverProcessor.hpp"
+#include "CloverFragProcessor.hpp"
 #include "DoubleBetaProcessor.hpp"
 #include "DssdProcessor.hpp"
 #include "GammaScintProcessor.hpp"
@@ -120,7 +121,13 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
                     processor.attribute("cycle_gate1_max").as_double(0.0),
                     processor.attribute("cycle_gate2_min").as_double(0.0),
                     processor.attribute("cycle_gate2_max").as_double(0.0)));
-        } else if (name == "DoubleBetaProcessor") {
+        } else if (name == "CloverFragProcessor") {
+            vecProcess.push_back(new CloverFragProcessor(
+                    processor.attribute("gammaThresh").as_double(0.0),
+                    processor.attribute("vetoThresh").as_double(0.0),
+                    processor.attribute("ionTrigThresh").as_double(0.0),
+                    processor.attribute("betaThresh").as_double(0.0)));
+        }else if (name == "DoubleBetaProcessor") {
             vecProcess.push_back(new DoubleBetaProcessor());
         } else if (name == "DssdProcessor") {
             vecProcess.push_back(new DssdProcessor());

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -187,9 +187,12 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
         } else if (name == "PspmtProcessor") {
             vecProcess.push_back(new PspmtProcessor(
                     processor.attribute("vd").as_string("SIB062_0926"),
-                    processor.attribute("scale").as_double(500.0),
-                    processor.attribute("offset").as_double(500.0),
-                    processor.attribute("threshold").as_double(50.0)
+                    processor.attribute("yso_scale").as_double(500.0),
+                    processor.attribute("yso_offset").as_double(500.0),
+                    processor.attribute("yso_threshold").as_double(50.0),
+                    processor.attribute("front_scale").as_double(500.0),
+                    processor.attribute("front_offset").as_double(500.0),
+                    processor.attribute("front_threshold").as_double(50.0)
             ));
         } else if (name == "TeenyVandleProcessor") {
             vecProcess.push_back(new TeenyVandleProcessor());

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -188,10 +188,10 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
             vecProcess.push_back(new PspmtProcessor(
                     processor.attribute("vd").as_string("SIB062_0926"),
                     processor.attribute("yso_scale").as_double(500.0),
-                    processor.attribute("yso_offset").as_double(500.0),
+                    processor.attribute("yso_offset").as_uint(500.0),
                     processor.attribute("yso_threshold").as_double(50.0),
                     processor.attribute("front_scale").as_double(500.0),
-                    processor.attribute("front_offset").as_double(500.0),
+                    processor.attribute("front_offset").as_uint(500.0),
                     processor.attribute("front_threshold").as_double(50.0),
                     processor.attribute("rotation").as_double(0.0)
             ));
@@ -203,7 +203,8 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
             vecProcess.push_back(new VandleProcessor(
                     StringManipulation::TokenizeString(processor.attribute("types").as_string("medium"), ","),
                     processor.attribute("res").as_double(2.0), processor.attribute("offset").as_double(1000.0),
-                    processor.attribute("NumStarts").as_uint(1), processor.attribute("compression").as_double(1.0)));
+                    processor.attribute("NumStarts").as_uint(1), processor.attribute("compression").as_double(1.0),
+                    processor.attribute("qdcmin").as_double(0.0),processor.attribute("tofcut").as_double(-1000.0)));
         } else if (name == "TemplateExpProcessor") {
             vecProcess.push_back(new TemplateExpProcessor());
         } else if (name == "E11027Processor") {

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -155,9 +155,10 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
             vecProcess.push_back(new TemplateExpProcessor());
         } else if (name == "ExtTSSenderProcessor") {
             vecProcess.push_back(new ExtTSSenderProcessor(
-                    processor.attribute("type").as_string("pspmpt:dynode"),
+                    processor.attribute("type").as_string(""),
                     processor.attribute("host").as_string("localhost"),
-                    processor.attribute("tag").as_string("beta"),
+                    processor.attribute("slot").as_int(0),
+                    processor.attribute("channel").as_int(0),
                     processor.attribute("port").as_int(12345),
                     processor.attribute("buffSize").as_uint(64)));
         }

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -42,6 +42,7 @@
 #include "TeenyVandleProcessor.hpp"
 #include "TemplateProcessor.hpp"
 #include "VandleProcessor.hpp"
+#include "ExtTSSenderProcessor.hpp"
 
 //These headers are for handling experiment specific processing.
 #include "E11027Processor.hpp"
@@ -152,6 +153,13 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
             vecProcess.push_back(new E11027Processor());
         } else if (name == "TemplateExpProcessor") {
             vecProcess.push_back(new TemplateExpProcessor());
+        } else if (name == "ExtTSSenderProcessor") {
+            vecProcess.push_back(new ExtTSSenderProcessor(
+                    processor.attribute("type").as_string("pspmpt:dynode"),
+                    processor.attribute("host").as_string("localhost"),
+                    processor.attribute("tag").as_string("beta"),
+                    processor.attribute("port").as_int(12345),
+                    processor.attribute("buffSize").as_uint(64)));
         }
 #ifdef useroot //Certain processors REQUIRE ROOT to actually work
         else if (name == "Anl1471Processor") {

--- a/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
@@ -31,6 +31,8 @@ void MapNodeXmlParser::ParseNode(DetectorLibrary *lib) {
         throw GeneralException("MapNodeXmlParser::ParseNode : Global TraceDelay must be set and greater than 0");
 
     int globalModFreq = map.attribute("frequency").as_int(-1);
+    if (globalModFreq <0)
+        throw GeneralException("MapNodeXmlParser::ParseNode : Global Frequency must be set");
 
     TreeCorrelator *tree = TreeCorrelator::get();
 
@@ -63,7 +65,7 @@ void MapNodeXmlParser::ParseNode(DetectorLibrary *lib) {
                 messenger_.detail(sstream_.str(),1);
                 sstream_.str("");
             }
-            sstream_ << "Module " << module_number << " Trace Delay= " << module_TdelayNs<<" ns";
+            sstream_ << "Module " << module_number << " Trace Delay = " << module_TdelayNs<<" ns";
             messenger_.detail(sstream_.str(),2);
             sstream_.str("");
         }

--- a/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
@@ -95,6 +95,7 @@ void MapNodeXmlParser::ParseNode(DetectorLibrary *lib) {
 
             chanCfg.SetType(channel.attribute("type").as_string("ignore"));
             chanCfg.SetSubtype(channel.attribute("subtype").as_string("ignore"));
+            chanCfg.SetGroup(channel.attribute("group").as_string("ignore"));
 
             if (channel.attribute("location").as_int(-1) == -1)
                 chanCfg.SetLocation(lib->GetNextLocation(chanCfg.GetType(), chanCfg.GetSubtype()));

--- a/Analysis/Utkscan/core/source/UtkScanInterface.cpp
+++ b/Analysis/Utkscan/core/source/UtkScanInterface.cpp
@@ -40,9 +40,10 @@ bool UtkScanInterface::Initialize(string prefix_) {
     if (init_)
         return false;
 
+#ifndef USE_HRIBF
     if (GetOutputFilename() == "")
         throw invalid_argument("UtkScaninterface::Initialize : The output file name was not provided.");
-
+#endif
     try {
         cout << "UtkScanInterface::Initialize : Now attempting to load and "
                 "parse " << GetSetupFilename() << endl;

--- a/Analysis/Utkscan/core/source/utkscanor.cpp
+++ b/Analysis/Utkscan/core/source/utkscanor.cpp
@@ -33,6 +33,7 @@ extern "C" void startup_() {
     // Initialize the scanner and handle command line arguments from SCANOR
     cout << "utkscan.cpp : Performing the setup routine" << endl;
     scanner->Setup(GetNumberArguments(), GetArguments(), unpacker);
+    Globals::get()->SetOutputFilename(GetArgument(1));
 
 
 }

--- a/Analysis/Utkscan/experiment/include/TwoChanTimingProcessor.hpp
+++ b/Analysis/Utkscan/experiment/include/TwoChanTimingProcessor.hpp
@@ -18,6 +18,8 @@ public:
     /** Default Destructor */
     ~TwoChanTimingProcessor();
 
+ /** Declare the plots used in the analysis */
+    virtual void DeclarePlots(void);  
 
     /** Performs the main processsing, which may depend on other processors
     * \param [in] event : the event to process

--- a/Analysis/Utkscan/experiment/source/TwoChanTimingProcessor.cpp
+++ b/Analysis/Utkscan/experiment/source/TwoChanTimingProcessor.cpp
@@ -32,6 +32,12 @@ enum CODES {
     WRONG_NUM
 };
 
+namespace dammIds{
+  namespace experiment{
+    const int DD_PHASEPHASE = 0;
+  }
+}
+
 using namespace std;
 using namespace dammIds::experiment;
 
@@ -39,28 +45,26 @@ TwoChanTimingProcessor::TwoChanTimingProcessor() :
         EventProcessor(OFFSET, RANGE, "TwoChanTimingProcessor") {
     associatedTypes.insert("pulser");
 
-    rootfile =
-            new TFile(Globals::get()->AppendOutputPath(
-                    Globals::get()->GetOutputFileName() + ".root").c_str(),
-                      "RECREATE");
+    rootfile = new TFile(Globals::get()->AppendOutputPath(Globals::get()->GetOutputFileName() + ".root").c_str(), "RECREATE");
 
     tree = new TTree("timing", "");
-    tree->Branch("start", &rstart,
-                 "qdc/D:time:snr:wtime:phase:abase:sbase:id/b");
+    tree->Branch("start", &rstart, "qdc/D:time:snr:wtime:phase:abase:sbase:id/b");
     tree->Branch("stop", &rstop, "qdc/D:time:snr:wtime:phase:abase:sbase:id/b");
     codes = new TH1I("codes", "", 20, 0, 20);
     startTraces = new TH2I("startTraces", "", 250, 0, 250, 2000, 0, 2000);
     stopTraces = new TH2I("stopTraces", "", 250, 0, 250, 2000, 0, 2000);
-    startAmpDistribution =
-            new TH2I("startAmpDistribution", "", 250, 0, 250, 16384, 0, 16384);
-    stopAmpDistribution =
-            new TH2I("stopAmpDistribution", "", 250, 0, 250, 16384, 0, 16384);
+    startAmpDistribution = new TH2I("startAmpDistribution", "", 250, 0, 250, 16384, 0, 16384);
+    stopAmpDistribution = new TH2I("stopAmpDistribution", "", 250, 0, 250, 16384, 0, 16384);
 }
 
 TwoChanTimingProcessor::~TwoChanTimingProcessor() {
     codes->Write();
     rootfile->Write();
     rootfile->Close();
+}
+
+void TwoChanTimingProcessor::DeclarePlots(void){
+  DeclareHistogram2D(DD_PHASEPHASE,SD,SD,"Start Phase vs Stop Phase");
 }
 
 bool TwoChanTimingProcessor::Process(RawEvent &event) {
@@ -123,6 +127,9 @@ bool TwoChanTimingProcessor::Process(RawEvent &event) {
         tree->Fill();
         start.ZeroRootStructure(rstart);
         stop.ZeroRootStructure(rstop);
+
+	//damm plots here
+	plot(DD_PHASEPHASE,start.GetPhaseInNs(),stop.GetPhaseInNs());
     }
     EndProcess();
     return true;

--- a/Analysis/Utkscan/processors/include/CloverFragProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/CloverFragProcessor.hpp
@@ -1,0 +1,63 @@
+///@file CloverFragProcessor.hpp
+///@brief Processor for Clovers at Fragmentation Facilities (Based HEAVILY on CloverProcessor.cpp)
+///@authors T.T. King
+
+#ifndef PAASS_CLOVERFRAGPROCESSOR_H
+#define PAASS_CLOVERFRAGPROCESSOR_H
+
+#include <map>
+#include <vector>
+#include <utility>
+#include <cmath>
+
+#include "EventProcessor.hpp"
+#include "ProcessorRootStruc.hpp"
+#include "RawEvent.hpp"
+
+#include "DammPlotIds.hpp"
+#include "Messenger.hpp"
+#include "pugixml.hpp"
+#include "StringManipulationFunctions.hpp"
+
+class CloverFragProcessor : public EventProcessor {
+public:
+    /**Constructor
+     * \param [in] gammaThreshold : Set threshold for gammarays
+     * \param [in] vetoThresh : Set threshold for lightIon veto
+     * \param [in] ionTrigThresh : Set threshold for ion Trigger
+     */
+    CloverFragProcessor(double gammaThreshold, double vetoThresh, double ionTrigThresh, double betaThresh);
+
+    /** Deconstructor */
+    ~CloverFragProcessor() = default;
+
+    /** Preprocess the event
+    * \param [in] event : the event to preprocess
+    * \return true if successful
+    */
+    virtual bool PreProcess(RawEvent &event);
+
+    /** Process the event
+     * \param [in] event : the event to process
+     * \return true if successful
+     */
+    virtual bool Process(RawEvent &event);
+
+    /** Declare the plots for the processor */
+    virtual void DeclarePlots(void);
+
+    /** Build Clovers */
+    void CloverBuilder(const std::set<int> &cloverLocs);
+
+private:
+    static const unsigned int chansPerClover = 4; /*!< number of channels per clover */
+
+    std::map<int, int> leafToClover;   /*!< Translate a leaf location to a clover number */
+    unsigned int numClovers;           /*!< number of clovers in map */
+
+    double gammaThresh_,vetoThresh_,ionTrigThresh_,betaThresh_; //!<Thresholds
+
+    processor_struct::CLOVERS Cstruct; //!<Root Struct
+};
+
+#endif //PAASS_CLOVERFRAGPROCESSOR_H

--- a/Analysis/Utkscan/processors/include/CloverProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/CloverProcessor.hpp
@@ -14,7 +14,7 @@
 #include "RawEvent.hpp"
 
 namespace dammIds {
-    //! Namespace containing histogram definitions for the GE
+    //! Namespace containing histogram definitions for the Clover
     namespace clover {
         /**
         * Naming conventions:
@@ -105,7 +105,7 @@ namespace dammIds {
                 const int DD_ADD_ENERGY_PROMPT = 163;//!< beta/multi gated addback energy
             }
         }
-    } // end namespace ge
+    } // end namespace clover
 }
 
 #ifdef GGATES

--- a/Analysis/Utkscan/processors/include/CloverProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/CloverProcessor.hpp
@@ -219,8 +219,6 @@ public:
     /** Returns the events that were added to the tas_ */
     std::vector<AddBackEvent> GetTasEvents(void) { return (tas_); }
 
-    std::vector<CLOVERS> GetCloverVec() { return Csing; }
-
 protected:
     static const unsigned int chansPerClover = 4; /*!< number of channels per clover */
 
@@ -305,8 +303,7 @@ protected:
     double cycle_gate2_min_;//!< low value for second cycle gate
     double cycle_gate2_max_;//!< high value for second cycle gate
 
-    CLOVERS Cstruct , DefaultStruct; //!<Structure for the current chanEvt data
-    std::vector<CLOVERS> Csing; //!<vector containing the PixieEvent's list of data
+    processor_struct::CLOVERS Cstruct;
 };
 
 #endif // __CloverProcessor_HPP_

--- a/Analysis/Utkscan/processors/include/CloverProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/CloverProcessor.hpp
@@ -10,6 +10,7 @@
 #include <cmath>
 
 #include "EventProcessor.hpp"
+#include "ProcessorRootStruc.hpp"
 #include "RawEvent.hpp"
 
 namespace dammIds {
@@ -156,22 +157,24 @@ class AddBackEvent {
 public:
     /** Default constructor setting things to zero */
     AddBackEvent() {
-        energy = time = multiplicity = 0;
+        energy = time = multiplicity = ftime = 0;
     }
 
     /** Default constructor setting default values
      * \param [in] ienergy : the initial energy
      * \param [in] itime : the initial time
      * \param [in] imultiplicity : multiplicity of the event */
-    AddBackEvent(double ienergy, double itime, unsigned imultiplicity) {
+    AddBackEvent(double ienergy, double itime, unsigned imultiplicity,double ifirsttime) {
         energy = ienergy;
         time = itime;
         multiplicity = imultiplicity;
+        ftime = ifirsttime;
     }
 
     double energy;//!< Energy of the addback event
     double time;//!< time of the addback event
     unsigned multiplicity;//!< multiplicity of the event
+    double ftime;//!<first time in the event
 };
 
 //! Processor to handle Ge (read as clover) events
@@ -211,11 +214,12 @@ public:
     std::vector<ChanEvent *> GetGeEvents(void) { return (geEvents_); }
 
     /** Returns the events that were added to the addbackEvents_ */
-    std::vector<std::vector<AddBackEvent>>
-    GetAddbackEvents(void) { return (addbackEvents_); }
+    std::vector<std::vector<AddBackEvent>> GetAddbackEvents(void) { return (addbackEvents_); }
 
     /** Returns the events that were added to the tas_ */
     std::vector<AddBackEvent> GetTasEvents(void) { return (tas_); }
+
+    std::vector<CLOVERS> GetCloverVec() { return Csing; }
 
 protected:
     static const unsigned int chansPerClover = 4; /*!< number of channels per clover */
@@ -266,6 +270,7 @@ protected:
      * \param [in] bin2 : the second bin to plot into */
     void symplot(int dammID, double bin1, double bin2);
 
+
     /** addbackEvents vector of vectors, where first vector
      * enumerates cloves, second events */
     std::vector<std::vector<AddBackEvent>> addbackEvents_;
@@ -299,6 +304,9 @@ protected:
     double cycle_gate1_max_;//!< high value for first cycle gate
     double cycle_gate2_min_;//!< low value for second cycle gate
     double cycle_gate2_max_;//!< high value for second cycle gate
+
+    CLOVERS Cstruct , DefaultStruct; //!<Structure for the current chanEvt data
+    std::vector<CLOVERS> Csing; //!<vector containing the PixieEvent's list of data
 };
 
 #endif // __CloverProcessor_HPP_

--- a/Analysis/Utkscan/processors/include/DoubleBetaProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/DoubleBetaProcessor.hpp
@@ -43,6 +43,8 @@ public:
 private:
     BarMap bars_; //!< Map holding all the bars we found 
     std::map<unsigned int, std::pair<double, double> > lrtbars_; //!< map holding low res bars
+    processor_struct::DOUBLEBETA DBstruc; //!<Root Struct
+
 };
 
 #endif // __DOUBLEBETAPROCESSOR_HPP__

--- a/Analysis/Utkscan/processors/include/EventProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/EventProcessor.hpp
@@ -13,6 +13,7 @@
 
 #include "Plots.hpp"
 #include "TreeCorrelator.hpp"
+#include "ProcessorRootStruc.hpp"
 
 // forward declarations
 class DetectorSummary;
@@ -106,6 +107,11 @@ public:
     virtual void FillBranch(void) {};
 #endif
 
+    /** returns PixTreeEvent for ROOT tree output **/
+    PixTreeEvent* GetPixTreeEvent() const { return pixie_tree_event_; }
+
+    void SetPixTreeEventPtr(PixTreeEvent* pix_tree_event) { pixie_tree_event_ = pix_tree_event; }
+
 protected:
     std::string name; //!< Name of the Processor
     std::set<std::string> associatedTypes; //!< Set of associated types for Processor
@@ -116,6 +122,9 @@ protected:
     /** Plots class for given Processor, takes care of declaration
     * and plotting within boundaries allowed by PlotsRegistry */
     Plots histo;
+
+    /** tree event data container for ROOT output **/
+    PixTreeEvent *pixie_tree_event_;
 
     /*! \brief Implementation of the plot command to interface with the DAMM
     * routines

--- a/Analysis/Utkscan/processors/include/ExtTSSenderProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/ExtTSSenderProcessor.hpp
@@ -17,8 +17,9 @@
 class ExtTSSenderProcessor : public EventProcessor {
 
 private:
-    std::string type_; //!< A type of the detector to send timestamp
-    std::string tag_; //!< A tag of the ch to send timestamp
+    std::string type_; //!< The host name of the server
+    int slotNum_; //!< Slot number of the detector to send timestamp
+    int chanNum_; //!< Channel number of the ch to send timestamp
     int port_; //!< A port number to communicate
     std::string hostName_; //!< The host name of the server
     Client* udpClient_; //!< A udp client in poll2_socket.h
@@ -36,7 +37,7 @@ public:
     // @param [in] port : the port number of the server to send the timestamps
     // @param [in] buffSize : the size of the buffer in 64 bit integer
     ExtTSSenderProcessor(const std::string &type, const std::string &hostName,
-                         const std::string &tag, const int &port, const int &buffSize);
+                         const int &slot, const int &channel,  const int &port, const int &buffSize);
 
     // Default destructor
     ~ExtTSSenderProcessor();

--- a/Analysis/Utkscan/processors/include/ExtTSSenderProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/ExtTSSenderProcessor.hpp
@@ -1,0 +1,70 @@
+///@file ExtTSSenderProcessor.hpp
+///@brief A class to send external timestamp info of a given detector
+/// to a server by udp
+///@author R. Yokoyama
+///@date 23 May 2018
+
+#ifndef __EXTTSSENDERPROCESSOR_HPP_
+#define __EXTTSSENDERPROCESSOR_HPP_
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include "poll2_socket.h"
+#include "EventProcessor.hpp"
+#include "RawEvent.hpp"
+
+class ExtTSSenderProcessor : public EventProcessor {
+
+private:
+    std::string type_; //!< A type of the detector to send timestamp
+    std::string tag_; //!< A tag of the ch to send timestamp
+    int port_; //!< A port number to communicate
+    std::string hostName_; //!< The host name of the server
+    Client* udpClient_; //!< A udp client in poll2_socket.h
+    unsigned long long int *buffer_; //!< A data buffer for sending
+    unsigned int buffSize_; //!< A buffer size in 64 bit
+    unsigned int curPos_; //!< A counter
+
+public:
+    // Default constructor
+    ExtTSSenderProcessor();
+
+    // Constructor taking the detector type and udp settings as arguments
+    // @param [in] type : the type of the detector to send its timestamps
+    // @param [in] hostName : the host name of the server to send the timestamps
+    // @param [in] port : the port number of the server to send the timestamps
+    // @param [in] buffSize : the size of the buffer in 64 bit integer
+    ExtTSSenderProcessor(const std::string &type, const std::string &hostName,
+                         const std::string &tag, const int &port, const int &buffSize);
+
+    // Default destructor
+    ~ExtTSSenderProcessor();
+ 
+    // Process the data and send external timestamp of given detector
+    virtual bool Process(RawEvent &event);
+
+    //Set buffSize_ and recreate the buffer_
+    void SetBuffSize(const unsigned int &buffSize);
+
+    //Initialization
+    bool Init(const std::string &host_name, const int &port);
+
+    //To be called each time to fill a timestamp to be sent later when the buffer
+    //becomes full
+    void SetTS(const unsigned long long int &ts);
+
+    //Send a whole buffer content with udp to the server
+    int SendTS();
+
+    //Close udp client
+    void Close(){udpClient_->Close();}
+
+    //Clear all content of the buffer to 0
+    void ClearBuff();
+
+    int GetPort() const { return port_; }
+    std::string GetHostName() const { return hostName_; }
+};
+
+#endif //__EXTTSSENDERPROCESSOR_HPP_

--- a/Analysis/Utkscan/processors/include/GSaddback.hpp
+++ b/Analysis/Utkscan/processors/include/GSaddback.hpp
@@ -5,7 +5,9 @@ class GSAddback {
 public:
     /** Default constructor setting things to zero */
     GSAddback() {
-        energy = time = multiplicity = abevtnum=ftime = 0;
+        energy = time = ftime = 0;
+        multiplicity = 0;
+
     }
     /** Default deconstructor */
 
@@ -13,21 +15,19 @@ public:
 
     /** Default constructor setting default values
      * \param [in] ienergy : the initial energy
-     * \param [in] itime : the initial time
-     * \param [in] imultiplicity : multiplicity of the event
-     * \param [in] iEvtNum: Pixie event number of the event (comes from DetectorDriver)*/
-    GSAddback(double ienergy, double itime, double iftime, unsigned imultiplicity, unsigned long iEvtNum) {
+     * \param [in] itime : the time
+     * \param [in] ftime : the initial time
+     * \param [in] imultiplicity : multiplicity of the event*/
+    GSAddback(double ienergy, double itime, double iftime, unsigned imultiplicity) {
         energy = ienergy;
         time = itime;
         multiplicity = imultiplicity;
-        abevtnum= iEvtNum;
         ftime = iftime;
     }
 
     double energy;//!< Energy of the addback event
     double time;//!< time of the addback event
     unsigned multiplicity;//!< multiplicity of the event
-    unsigned long abevtnum;//!<pixie event number of the last det event added to the addback calc
     double ftime;//<! first time in the event
 };
 

--- a/Analysis/Utkscan/processors/include/GSaddback.hpp
+++ b/Analysis/Utkscan/processors/include/GSaddback.hpp
@@ -1,0 +1,34 @@
+#ifndef GSAddback_h
+#define GSAddback_h
+
+class GSAddback {
+public:
+    /** Default constructor setting things to zero */
+    GSAddback() {
+        energy = time = multiplicity = abevtnum=ftime = 0;
+    }
+    /** Default deconstructor */
+
+    ~GSAddback(){};
+
+    /** Default constructor setting default values
+     * \param [in] ienergy : the initial energy
+     * \param [in] itime : the initial time
+     * \param [in] imultiplicity : multiplicity of the event
+     * \param [in] iEvtNum: Pixie event number of the event (comes from DetectorDriver)*/
+    GSAddback(double ienergy, double itime, double iftime, unsigned imultiplicity, unsigned long iEvtNum) {
+        energy = ienergy;
+        time = itime;
+        multiplicity = imultiplicity;
+        abevtnum= iEvtNum;
+        ftime = iftime;
+    }
+
+    double energy;//!< Energy of the addback event
+    double time;//!< time of the addback event
+    unsigned multiplicity;//!< multiplicity of the event
+    unsigned long abevtnum;//!<pixie event number of the last det event added to the addback calc
+    double ftime;//<! first time in the event
+};
+
+#endif //end include guard

--- a/Analysis/Utkscan/processors/include/GammaScintProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/GammaScintProcessor.hpp
@@ -62,12 +62,6 @@ public:
     virtual bool Process(RawEvent &event);
 
 
-    /**Returns the vector of GScint singles events. used for coincidence plotting in root
-     *
-     * @return vector of GS singles
-     */
-    std::vector<GAMMASCINT> GetGSVector(){ return PEsing;}
-
     std::map<std::string,std::string> GetTHeader(){return Theader;}
 
 protected:
@@ -182,8 +176,7 @@ private:
     std::vector<float> timeScales_; //!< list of time scales to plot (10 ms always present depending on EvsT)
     std::string BunchingTimestr_;//<!String containing the bunching time as parsed. (For rootfiles TNamed's)
 
-    GAMMASCINT Gsing,DefaultStruct; //!< structure of det event info for PEsing, as well as a default version for resetting
-    std::vector<GAMMASCINT> PEsing; //!< vector of detector events per pixie event
+    processor_struct::GAMMASCINT Gsing; //!< structure of det event info for PEsing
 
     std::map<std::string,std::string> Theader; // map of header info for the root file from this processor
 };

--- a/Analysis/Utkscan/processors/include/GammaScintProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/GammaScintProcessor.hpp
@@ -27,7 +27,7 @@
 #include <TBranch.h>
 #include <TH1.h>
 #include <TH2.h>
-#include "ProcessorStruc.hpp"
+#include "ProcessorRootStruc.hpp"
 #include "GSaddback.hpp"
 
 #endif

--- a/Analysis/Utkscan/processors/include/GammaScintProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/GammaScintProcessor.hpp
@@ -1,0 +1,192 @@
+///@file GammaScintProcessor.hpp
+///@brief Processor for Scintilation Gamma-ray detectors
+///@authors T.T. King
+
+#ifndef PAASS_GAMMASCINTPROCESSOR_HPP
+#define PAASS_GAMMASCINTPROCESSOR_HPP
+
+#include <ctime>
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include "DammPlotIds.hpp"
+#include "EventProcessor.hpp"
+#include "Messenger.hpp"
+#include "pugixml.hpp"
+#include "StringManipulationFunctions.hpp"
+
+
+#ifdef useroot
+
+#include "TROOT.h"
+#include "TSystem.h"
+#include <TFile.h>
+#include <TTree.h>
+#include <TBranch.h>
+#include <TH1.h>
+#include <TH2.h>
+#include "ProcessorStruc.hpp"
+#include "GSaddback.hpp"
+
+#endif
+
+class GammaScintProcessor : public EventProcessor {
+public:
+    ///Default Constructor
+    //GammaScintProcessor();
+
+    ///Default Destructor
+    ~GammaScintProcessor();
+
+    ///Constructor taking a list of detector types as an argument
+    ///@param [in] GSArgs : Map of "Arguments" for the processor, HRBWin, FacilityType, etc (Check GammaScintProcessor.hpp for more)
+    ///@param [in] typeList : the list of bar types that are in the analysis
+    ///@param [in] timeScales : list of time scales used in the energy vs time plots (units are Secs)
+    GammaScintProcessor(const std::map<std::string,std::string> &GSArgs,
+                        const std::vector<std::string> &typeList,
+                        const std::vector<std::string> &timeScales);
+
+    ///Declare the plots for the processor
+    virtual void DeclarePlots(void);
+
+    /// Preprocess the Event
+    /// \param [in] event : the event to preprocess
+    /// \return true if successful
+    virtual bool PreProcess(RawEvent &event);
+
+    ///Process the event
+    /// \param [in] event : the event to process
+    /// \return Returns true if the processing was successful
+    virtual bool Process(RawEvent &event);
+
+
+    /**Returns the vector of GScint singles events. used for coincidence plotting in root
+     *
+     * @return vector of GS singles
+     */
+    std::vector<GAMMASCINT> GetGSVector(){ return PEsing;}
+
+    std::map<std::string,std::string> GetTHeader(){return Theader;}
+
+protected:
+    /** Declares a histogram with a range of time scales
+     * \param [in] dammId : the dammID to plot
+     * \param [in] xsize : the size in the x range
+     * \param [in] ysize : the size in the y range
+     * \param [in] title : the title of the histogram
+     * \param [in] halfWordsPerChan : the half words per channel (default is 1, cloverProcessor is 2)
+     * this is more or less the bit size of the bins (See Cory Thornsberry for more)
+     * \param [in] timeScale : the list of time scales to plot
+     * \param [in] units : the units for the plot */
+    void DeclareHistogramTimeY(int dammId, int xsize, int ysize,
+                               const char *title, int halfWordsPerChan,
+                               const std::vector<float> &timeScale,
+                               const char *units);
+
+    /** Declares a histogram with a single time scale
+     * \param [in] dammId : the dammID to plot
+     * \param [in] xsize : the size in the x range
+     * \param [in] ysize : the size in the y range
+     * \param [in] title : the title of the histogram
+     * \param [in] halfWordsPerChan : the half words per channel (default is 1, cloverProcessor is 2)
+     * this is more or less the bit size of the bins (See Cory Thornsberry for more)
+     * \param [in] timeScale : Time scale to plot
+     * \param [in] units : the units for the plot */
+    void DeclareHistogramTimeY(int dammId, int xsize, int ysize,
+                               const char *title, int halfWordsPerChan,
+                               const float &timeScale,
+                               const char *units);
+
+    /** Plotting function to plot in a specific granularity
+     * \param [in] dammId : the damm id to plot into
+     * \param [in] x : the x value to plot
+     * \param [in] y : the y value to plot
+     * \param [in] timeScale : the list of time scales to plot into */
+    void timePloty(int dammId, double x, double y,
+                   const std::vector<float> &timeScale);
+
+private:
+    /** Returns Damm Histo ID offsets for known types
+     * \param [in] subtype : The known subtype to lookup
+     * @return Returns the damm offset
+     */
+    unsigned int ReturnOffset(const std::string &subtype);
+
+    /** Returns the addback parameters for known types
+     * \param [in] subtype : The known subtype to lookup
+     * \param [in] option : Parameter to lookup
+     * @return Returns (by reference ) parameter
+     */
+    double GetAddbackPara(const std::string &subtype,const std::string &option);
+
+    /** Updates the Addback Reference time for known types
+     * \param [in] subtype : The subtype's whose RefTime needs updating
+     * \param [in] newRefTime : New Reference time
+     */
+    void SetAddbackRefTime(const std::string &subtype, const double &newRefTime);
+
+    /** Returns the addback struct for a specific type
+     * @param subtype
+     * @return Pointer to the GSAddback struct for the known subtypes
+     */
+    GSAddback* GetAddbackStruct(const std::string &subtype);
+
+    // Variable list
+    std::set<std::string> typeList_ ;//!< list of requested types
+    std::vector<ChanEvent *> GSEvents_; //!< Vector of GammaScint Events
+
+    /** The nested map structure is <subtype , < parameter , value > >.
+     *    Parameters are "thresh" , "subEvtWin", "refTime".
+     *    RefTimes and SubEvtWin need to be in seconds in the cfg but we convert to ticks for the running
+     */ std::map<std::string,std::map<std::string,double> > ParameterMap; //!<Map of addback parameters
+
+    bool hasTrigBeta_;//!<  has a Trigger (the GLobal Pixie Trigger; i.e. VANDLE's) Beta
+    bool hasLowResBeta_; //!< has Event (Low Res) Beta
+    bool hasMedResBeta_; //!< has Medium Res Beta
+    bool firstGSEvent_;//!< only True for Very First GammaScintEvent
+
+    double firstEventTime_; //!<Time for first event in the file
+    unsigned long evtNum_=0; //!< Event Number as received from Detector Driver (Master Evt Number)
+    std::pair<double, std::string> MRBetaWindow_ ;//!< Window size in nanoseconds for the Medium Res beta gate (mainly for LaBr3)
+    double bunchLast_; //!<Time of Last Long Time Scale Bunch ( in ns) (i.e. tape cycle or 30 sec bunch
+    double bunchingTime_;//!< Time bin size for energy vs Long time plot (frag type ONLY)
+    double MAXTIMEPLOTS=3; //!< Max number of extra Time scales to plot (excluding 10ms which is always made if EvsT == True).
+    //!< These Plots are add significant size to the output .his file. So we dont want to make too many of them
+
+    bool SysRoot_; //!<will the detectorDirver ask for root data
+    int bunchNum_ =0 ; //!<bunch number (bunch defined in bunchLast comment)
+
+    const int binDepth = 1; //!<With binDep 1 they dont add so much; (cloverProcessor uses 2, but the normal DeclareHis uses 1
+
+
+    //Vectors of Events for addback
+    GSAddback* LHaddBack_;//!<structure for Small HAGRiD addback 
+    GSAddback* NaddBack_;//!<structure for NaI addback
+    GSAddback* BHaddBack_;//!<structure for Big HAGRiD addback
+    GSAddback* FAILEDaddback_;//!< Numeric Limits vector for Failed GetAddbackStruct
+
+    /** Most Beta (actual beta type) events are Multi 1
+        but this allow for multiple beta decays in 1 pixie event (requires extreme rate)
+        This is a vector of a pair of doubles The data is stored as <<Time,Energy>,...>
+    */std::vector<std::pair<double,double>> BetaList;
+
+    std::map<unsigned int, std::pair<double, double> > lrtBetas; //!<Low Res Time beta bar map (ISOL style). Order is <Double Beta det #, < Time, Energy > >
+   
+    //input arguments
+    bool BetaGammGamm = false; //!< beta gamma gamma plots which are LARGE and not implamented yet. (might just dump to root rather than here)
+    bool ISOL_; //!<How to plot the energy vs Long Time scale; for tracking Drift
+    bool EvsT_; //!<Make Energy Vs Time plots?
+    std::string FacilType_ ; //!< String of the Facility Type (frag or ISOL)
+    std::vector<float> timeScales_; //!< list of time scales to plot (10 ms always present depending on EvsT)
+    std::string BunchingTimestr_;//<!String containing the bunching time as parsed. (For rootfiles TNamed's)
+
+    GAMMASCINT Gsing,DefaultStruct; //!< structure of det event info for PEsing, as well as a default version for resetting
+    std::vector<GAMMASCINT> PEsing; //!< vector of detector events per pixie event
+
+    std::map<std::string,std::string> Theader; // map of header info for the root file from this processor
+};
+
+
+#endif

--- a/Analysis/Utkscan/processors/include/LogicProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/LogicProcessor.hpp
@@ -101,6 +101,7 @@ private:
     bool NiftyGraph(RawEvent &event);
 
     processor_struct::LOGIC LogStruc; //root struc
+    double cycleNum ;
 };
 
 #endif // __LOGICPROCESSOR_HPP_

--- a/Analysis/Utkscan/processors/include/LogicProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/LogicProcessor.hpp
@@ -99,6 +99,8 @@ private:
     /** Prototype for a nifty graph, currently unimplemented 
      * \param [in] event : the raw event for plotting the nifty graph */
     bool NiftyGraph(RawEvent &event);
+
+    processor_struct::LOGIC LogStruc; //root struc
 };
 
 #endif // __LOGICPROCESSOR_HPP_

--- a/Analysis/Utkscan/processors/include/LogicProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/LogicProcessor.hpp
@@ -100,8 +100,6 @@ private:
      * \param [in] event : the raw event for plotting the nifty graph */
     bool NiftyGraph(RawEvent &event);
 
-    processor_struct::LOGIC LogStruc; //root struc
-    double cycleNum ;
 };
 
 #endif // __LOGICPROCESSOR_HPP_

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -5,6 +5,7 @@
 #define PAASS_PROCESSORSTRUC_HPP
 
 #include <TObject.h>
+#include <TString.h>
 
 namespace processor_struct {
     struct VANDLES {
@@ -29,9 +30,8 @@ namespace processor_struct {
         bool isDynodeOut = false;
         int detNum = -999;
         double time = -999;
-        int NumGroup = -1; // spacial groups for addback
-        int NumType = -1; // REQUIRES a Type condition to separate the types; order in decreasing mass, 0 = nai, 1 = big hag, 2= small hag
-
+        TString group = "";
+        TString subtype = "";
     } ;
     static const GAMMASCINT GAMMASCINT_DEFAULT_STRUCT;
 

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -14,10 +14,12 @@ namespace processor_struct {
         double qdc=0;
         int barNum=0;
         std::string barType="";
-        double tdiff=0;
-        double sTime=0; //start detector time
+        double tdiff=-999;
         unsigned int sNum =0; //start detector number
         int vMulti=0;
+        double sTime = -999;
+        double sQdc = -999;
+
     } ;
     static const VANDLES  VANDLES_DEFAULT_STRUCT;
     
@@ -31,18 +33,14 @@ namespace processor_struct {
         double Time = -999;
         double BetaGammaTDiff = -999;
         double BetaEnergy = -999;
-        double BetaMulti = -999;
         double BetaTime = -999;
         double EvtNum = -999;
         double BunchNum = -999;
         double LastBunchTime = -999;
-    
-        int NumGroup = -1; // group numbers (0-3) for small hag, 0-2 for nai.
+        int NumGroup = -1; // space groups for addback
         // REQUIRES a Type condition to separate the types
-        std::string Type = "";
-    
         int NumType = -1; //order in decreasing mass, 0 = nai, 1 = big hag, 2= small hag
-        std::string Group = "";
+
     } ;
     static const GAMMASCINT GAMMASCINT_DEFAULT_STRUCT;
     
@@ -51,35 +49,46 @@ namespace processor_struct {
         double LastCycleTime = -999;
         double Energy = -999;
         double RawEnergy =-999;
+        double BetaCloverTDiff = -999;
+        double BetaEnergy = -999;
+        double BetaTime = -999;
         int DetNum = -999;
         int CloverNum = -999;
         bool HasLowResBeta = false;
+        bool HasVeto = false;
+        bool HasIonTrig = false;
     
     };
     static const CLOVERS CLOVERS_DEFAULT_STRUCT;
     
     struct PSPMT { 
-      ///Contains both low and high gain PSPMT information
-      double xa_l = -999; 
-      double xb_l = -999; 
-      double ya_l = -999; 
-      double yb_l = -999; 
-      double xa_h = -999; 
-      double xb_h = -999; 
-      double ya_h = -999; 
-      double yb_h = -999; 
-      double dy_l = -999;
-      double dy_h = -999;
-      double dyL_time = -999;
-      double dyH_time = -999;
-      double xposL =-999;
-      double yposL =-999;
-      double xposH =-999;
-      double yposH =-999;
-      int anodeLmulti = -999;
-      int anodeHmulti = -999;
-      int dyLmulti = -999;
-      int dyHmulti = -999;
+        ///Contains both low and high gain PSPMT information
+        double xa_l = -999;
+        double xb_l = -999;
+        double ya_l = -999;
+        double yb_l = -999;
+        double xa_h = -999;
+        double xb_h = -999;
+        double ya_h = -999;
+        double yb_h = -999;
+        double dy_l = -999;
+        double dy_h = -999;
+        double dyL_time = -999;
+        double dyH_time = -999;
+        double xposL =-999;
+        double yposL =-999;
+        double xposH =-999;
+        double yposH =-999;
+        int anodeLmulti = -999;
+        int anodeHmulti = -999;
+        int dyLmulti = -999;
+        int dyHmulti = -999;
+        double vetoEn0 = -999;
+        double vetoEn1 = -999;
+        double ionTrigEn0 = -999;
+        double ionTrigEn1 = -999;
+        double ionTrigEn2 = -999;
+        double ionTrigEn3 = -999;
     };
     static const PSPMT  PSPMT_DEFAULT_STRUCT;
 }    

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -89,6 +89,17 @@ class PixTreeEvent : public TObject
 public:
 
     PixTreeEvent(){}
+
+    /* copy constructor */
+    PixTreeEvent( const PixTreeEvent &obj ):TObject(obj)
+    {
+        externalTS = obj.externalTS;
+        clover_vec_ = obj.clover_vec_;
+        gamma_scint_vec_ = obj.gamma_scint_vec_;
+        vandle_vec_ = obj.vandle_vec_;
+        pspmt_vec_ = obj.pspmt_vec_;
+    }
+
     virtual ~PixTreeEvent(){}
 
     /* clear vectors and init all the values */

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -12,8 +12,7 @@ struct VANDLES {
     std::string barType="";
     double tdiff=0;
     double sTime=0;
-    unsigned long vMulti=0;
-    unsigned long long ExtTimeStamp=0;
+    int vMulti=0;
 } ;
 
 struct GAMMASCINT{

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -78,39 +78,14 @@ namespace processor_struct {
     static const LOGIC LOGIC_DEFAULT_STRUCT;
 
     struct PSPMT { 
-        ///Contains both low and high gain PSPMT information
-        double xa_l = -999;
-        double xb_l = -999;
-        double ya_l = -999;
-        double yb_l = -999;
-        double xa_h = -999;
-        double xb_h = -999;
-        double ya_h = -999;
-        double yb_h = -999;
-        double dy_l = -999;
-        double dy_h = -999;
-        double dyL_time = -999;
-        double dyH_time = -999;
-        double xposL =-999;
-        double yposL =-999;
-        double xposH =-999;
-        double yposH =-999;
-        int anodeLmulti = -999;
-        int anodeHmulti = -999;
-        int dyLmulti = -999;
-        int dyHmulti = -999;
-        double vetoEn0 = -999;
-        double vetoEn1 = -999;
-        double ionTrigEn0 = -999;
-        double ionTrigEn1 = -999;
-        double ionTrigEn2 = -999;
-        double ionTrigEn3 = -999;
-        bool hasVeto = false;
-        bool hasIonTrig = false;
+        double energy = -999;
+        double time = -999;
+        TString subtype = "";
+        TString tag = "";
     };
     static const PSPMT  PSPMT_DEFAULT_STRUCT;
 }    
- 
+
 class PixTreeEvent : public TObject
 {
 public:

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -24,43 +24,59 @@ namespace processor_struct {
     static const VANDLES  VANDLES_DEFAULT_STRUCT;
     
     struct GAMMASCINT{
-        bool HasLowResBeta = false;
-        bool HasTrigBeta =false;
-        double Energy = -999;
-        double RawEnergy = -999;
-        bool IsDynodeOut = false;
-        int DetNum = -999;
-        double Time = -999;
-        double BetaGammaTDiff = -999;
-        double BetaEnergy = -999;
-        double BetaTime = -999;
-        double EvtNum = -999;
-        double BunchNum = -999;
-        double LastBunchTime = -999;
-        int NumGroup = -1; // space groups for addback
-        // REQUIRES a Type condition to separate the types
-        int NumType = -1; //order in decreasing mass, 0 = nai, 1 = big hag, 2= small hag
+        double energy = -999;
+        double rawEnergy = -999;
+        bool isDynodeOut = false;
+        int detNum = -999;
+        double time = -999;
+        int NumGroup = -1; // spacial groups for addback
+        int NumType = -1; // REQUIRES a Type condition to separate the types; order in decreasing mass, 0 = nai, 1 = big hag, 2= small hag
 
     } ;
     static const GAMMASCINT GAMMASCINT_DEFAULT_STRUCT;
-    
-    struct CLOVERS{
-        double Time = -999;
-        double LastCycleTime = -999;
-        double Energy = -999;
-        double RawEnergy =-999;
-        double BetaCloverTDiff = -999;
-        double BetaEnergy = -999;
-        double BetaTime = -999;
-        int DetNum = -999;
-        int CloverNum = -999;
-        bool HasLowResBeta = false;
-        bool HasVeto = false;
-        bool HasIonTrig = false;
-    
+
+    struct DOUBLEBETA{
+        int detNum = -999;
+        double energy = -999;
+        double rawEnergy = -999;
+        double timeAvg = -999;
+        double timeDiff = -999;
+        double timeL = -999;
+        double timeR = -999;
+        double barQdc = -999;
+        double tMaxValL = -999;
+        double tMaxValR = -999;
+        bool isLowResBeta = false;
+        bool isHighResBeta = false;
     };
+    static const DOUBLEBETA DOUBLEBETA_DEFAULT_STRUCT;
+
+    struct CLOVERS{
+        double energy = -999;
+        double rawEnergy =-999;
+        double time = -999;
+        int detNum = -999;
+        int cloverNum = -999;
+    };
+
     static const CLOVERS CLOVERS_DEFAULT_STRUCT;
-    
+
+    struct LOGIC{
+        bool tapeCycleStatus = false;
+        bool beamStatus= false;
+        bool tapeMoving = false;
+
+        double lastTapeCycleStartTime = -999;
+        double lastBeamOnTime = -999;
+        double lastBeamOffTime = -999;
+        double lastTapeMoveStartTime = -999;
+        double lastProtonPulseTime = -999;
+        double lastSuperCycleTime = -999;
+
+        double cycleNum = -999;
+    };
+    static const LOGIC LOGIC_DEFAULT_STRUCT;
+
     struct PSPMT { 
         ///Contains both low and high gain PSPMT information
         double xa_l = -999;
@@ -89,6 +105,8 @@ namespace processor_struct {
         double ionTrigEn1 = -999;
         double ionTrigEn2 = -999;
         double ionTrigEn3 = -999;
+        bool hasVeto = false;
+        bool hasIonTrig = false;
     };
     static const PSPMT  PSPMT_DEFAULT_STRUCT;
 }    
@@ -105,9 +123,11 @@ public:
         externalTS1 = obj.externalTS1;
         externalTS2 = obj.externalTS2;
         clover_vec_ = obj.clover_vec_;
+        doublebeta_vec_ = obj.doublebeta_vec_;
         gamma_scint_vec_ = obj.gamma_scint_vec_;
-        vandle_vec_ = obj.vandle_vec_;
+        logic_vec_ = obj.logic_vec_;
         pspmt_vec_ = obj.pspmt_vec_;
+        vandle_vec_ = obj.vandle_vec_;
     }
 
     virtual ~PixTreeEvent(){}
@@ -118,18 +138,23 @@ public:
         externalTS1 = 0;
         externalTS2 = 0;
         clover_vec_.clear();
+        doublebeta_vec_.clear();
         gamma_scint_vec_.clear();
-        vandle_vec_.clear();
+        logic_vec_.clear();
         pspmt_vec_.clear();
+        vandle_vec_.clear();
+
     }
 
     /* data structures to be filled in the ROOT TTree */
     ULong64_t externalTS1 = 0;
     ULong64_t externalTS2 = 0;
     std::vector<processor_struct::CLOVERS> clover_vec_;
+    std::vector<processor_struct::DOUBLEBETA> doublebeta_vec_;
     std::vector<processor_struct::GAMMASCINT> gamma_scint_vec_;
-    std::vector<processor_struct::VANDLES> vandle_vec_;
+    std::vector<processor_struct::LOGIC> logic_vec_;
     std::vector<processor_struct::PSPMT> pspmt_vec_;
+    std::vector<processor_struct::VANDLES> vandle_vec_;
 
     ClassDef(PixTreeEvent,1)
 };

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -102,7 +102,8 @@ public:
     /* copy constructor */
     PixTreeEvent( const PixTreeEvent &obj ):TObject(obj)
     {
-        externalTS = obj.externalTS;
+        externalTS1 = obj.externalTS1;
+        externalTS2 = obj.externalTS2;
         clover_vec_ = obj.clover_vec_;
         gamma_scint_vec_ = obj.gamma_scint_vec_;
         vandle_vec_ = obj.vandle_vec_;
@@ -114,7 +115,8 @@ public:
     /* clear vectors and init all the values */
     virtual void Clear()
     {
-        externalTS = 0;
+        externalTS1 = 0;
+        externalTS2 = 0;
         clover_vec_.clear();
         gamma_scint_vec_.clear();
         vandle_vec_.clear();
@@ -122,7 +124,8 @@ public:
     }
 
     /* data structures to be filled in the ROOT TTree */
-    ULong64_t externalTS = 0;
+    ULong64_t externalTS1 = 0;
+    ULong64_t externalTS2 = 0;
     std::vector<processor_struct::CLOVERS> clover_vec_;
     std::vector<processor_struct::GAMMASCINT> gamma_scint_vec_;
     std::vector<processor_struct::VANDLES> vandle_vec_;

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -1,0 +1,54 @@
+/**Created by T.T. King 06/22/2018
+ * */
+#ifndef PAASS_PROCESSORSTRUC_HPP
+#define PAASS_PROCESSORSTRUC_HPP
+
+struct VANDLES {
+    double tof;
+    double corTof;
+    double qdcPos;
+    double qdc;
+    int barNum;
+    std::string barType;
+    double tdiff;
+    double sTime;
+    unsigned long vMulti;
+
+} ;
+
+struct GAMMASCINT{
+    bool HasLowResBeta = false;
+    bool HasTrigBeta =false;
+    double Energy = -999;
+    double RawEnergy = -999;
+    int DetNum = -999;
+    double Time = -999;
+    double BetaGammaTDiff = -999;
+    double BetaEnergy = -999;
+    double BetaMulti = -999;
+    double BetaTime = -999;
+    double EvtNum = -999;
+    double BunchNum = -999;
+    double LastBunchTime = -999;
+
+    int NumGroup = -1; // group numbers (0-3) for small hag, 0-2 for nai.
+    // REQUIRES a Type condition to separate the types
+    std::string Type = "";
+
+    int NumType = -1; //order in decreasing mass, 0 = nai, 1 = big hag, 2= small hag
+    std::string Group = "";
+} ;
+
+struct CLOVERS{
+    double Time = -999;
+    double LastCycleTime = -999;
+    double Energy = -999;
+    double RawEnergy =-999;
+    int DetNum = -999;
+    int CloverNum = -999;
+    bool HasLowResBeta = false;
+
+};
+
+
+#endif //PAASS_PROCESSORSTRUC_HPP

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -122,6 +122,8 @@ public:
     {
         externalTS1 = obj.externalTS1;
         externalTS2 = obj.externalTS2;
+        eventNum = obj.eventNum;
+        fileName = obj.fileName;
         clover_vec_ = obj.clover_vec_;
         doublebeta_vec_ = obj.doublebeta_vec_;
         gamma_scint_vec_ = obj.gamma_scint_vec_;
@@ -137,6 +139,8 @@ public:
     {
         externalTS1 = 0;
         externalTS2 = 0;
+        eventNum = 0;
+        fileName = "";
         clover_vec_.clear();
         doublebeta_vec_.clear();
         gamma_scint_vec_.clear();
@@ -149,6 +153,8 @@ public:
     /* data structures to be filled in the ROOT TTree */
     ULong64_t externalTS1 = 0;
     ULong64_t externalTS2 = 0;
+    Double_t eventNum = 0;
+    std::string fileName = "";
     std::vector<processor_struct::CLOVERS> clover_vec_;
     std::vector<processor_struct::DOUBLEBETA> doublebeta_vec_;
     std::vector<processor_struct::GAMMASCINT> gamma_scint_vec_;

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -4,16 +4,16 @@
 #define PAASS_PROCESSORSTRUC_HPP
 
 struct VANDLES {
-    double tof;
-    double corTof;
-    double qdcPos;
-    double qdc;
-    int barNum;
-    std::string barType;
-    double tdiff;
-    double sTime;
-    unsigned long vMulti;
-
+    double tof=0;
+    double corTof=0;
+    double qdcPos=0;
+    double qdc=0;
+    int barNum=0;
+    std::string barType="";
+    double tdiff=0;
+    double sTime=0;
+    unsigned long vMulti=0;
+    unsigned long long ExtTimeStamp=0;
 } ;
 
 struct GAMMASCINT{

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -1,79 +1,114 @@
 /**Created by T.T. King 06/22/2018
  * */
+/** PixTreeEvent class added by R. Yokoyama 08/31/2018 **/
 #ifndef PAASS_PROCESSORSTRUC_HPP
 #define PAASS_PROCESSORSTRUC_HPP
 
-struct VANDLES {
-    double tof=0;
-    double corTof=0;
-    double qdcPos=0;
-    double qdc=0;
-    int barNum=0;
-    std::string barType="";
-    double tdiff=0;
-    double sTime=0; //start detector time
-    unsigned int sNum =0; //start detector number
-    int vMulti=0;
-} ;
+#include <TObject.h>
 
-struct GAMMASCINT{
-    bool HasLowResBeta = false;
-    bool HasTrigBeta =false;
-    double Energy = -999;
-    double RawEnergy = -999;
-    bool IsDynodeOut = false;
-    int DetNum = -999;
-    double Time = -999;
-    double BetaGammaTDiff = -999;
-    double BetaEnergy = -999;
-    double BetaMulti = -999;
-    double BetaTime = -999;
-    double EvtNum = -999;
-    double BunchNum = -999;
-    double LastBunchTime = -999;
+namespace processor_struct {
+    struct VANDLES {
+        double tof=0;
+        double corTof=0;
+        double qdcPos=0;
+        double qdc=0;
+        int barNum=0;
+        std::string barType="";
+        double tdiff=0;
+        double sTime=0; //start detector time
+        unsigned int sNum =0; //start detector number
+        int vMulti=0;
+    } ;
+    static const VANDLES  VANDLES_DEFAULT_STRUCT;
+    
+    struct GAMMASCINT{
+        bool HasLowResBeta = false;
+        bool HasTrigBeta =false;
+        double Energy = -999;
+        double RawEnergy = -999;
+        bool IsDynodeOut = false;
+        int DetNum = -999;
+        double Time = -999;
+        double BetaGammaTDiff = -999;
+        double BetaEnergy = -999;
+        double BetaMulti = -999;
+        double BetaTime = -999;
+        double EvtNum = -999;
+        double BunchNum = -999;
+        double LastBunchTime = -999;
+    
+        int NumGroup = -1; // group numbers (0-3) for small hag, 0-2 for nai.
+        // REQUIRES a Type condition to separate the types
+        std::string Type = "";
+    
+        int NumType = -1; //order in decreasing mass, 0 = nai, 1 = big hag, 2= small hag
+        std::string Group = "";
+    } ;
+    static const GAMMASCINT GAMMASCINT_DEFAULT_STRUCT;
+    
+    struct CLOVERS{
+        double Time = -999;
+        double LastCycleTime = -999;
+        double Energy = -999;
+        double RawEnergy =-999;
+        int DetNum = -999;
+        int CloverNum = -999;
+        bool HasLowResBeta = false;
+    
+    };
+    static const CLOVERS CLOVERS_DEFAULT_STRUCT;
+    
+    struct PSPMT { 
+      ///Contains both low and high gain PSPMT information
+      double xa_l = -999; 
+      double xb_l = -999; 
+      double ya_l = -999; 
+      double yb_l = -999; 
+      double xa_h = -999; 
+      double xb_h = -999; 
+      double ya_h = -999; 
+      double yb_h = -999; 
+      double dy_l = -999;
+      double dy_h = -999;
+      double dyL_time = -999;
+      double dyH_time = -999;
+      double xposL =-999;
+      double yposL =-999;
+      double xposH =-999;
+      double yposH =-999;
+      int anodeLmulti = -999;
+      int anodeHmulti = -999;
+      int dyLmulti = -999;
+      int dyHmulti = -999;
+    };
+    static const PSPMT  PSPMT_DEFAULT_STRUCT;
+}    
+ 
+class PixTreeEvent : public TObject
+{
+public:
 
-    int NumGroup = -1; // group numbers (0-3) for small hag, 0-2 for nai.
-    // REQUIRES a Type condition to separate the types
-    std::string Type = "";
+    PixTreeEvent(){}
+    virtual ~PixTreeEvent(){}
 
-    int NumType = -1; //order in decreasing mass, 0 = nai, 1 = big hag, 2= small hag
-    std::string Group = "";
-} ;
+    /* clear vectors and init all the values */
+    virtual void Clear()
+    {
+        externalTS = 0;
+        clover_vec_.clear();
+        gamma_scint_vec_.clear();
+        vandle_vec_.clear();
+        pspmt_vec_.clear();
+    }
 
-struct CLOVERS{
-    double Time = -999;
-    double LastCycleTime = -999;
-    double Energy = -999;
-    double RawEnergy =-999;
-    int DetNum = -999;
-    int CloverNum = -999;
-    bool HasLowResBeta = false;
+    /* data structures to be filled in the ROOT TTree */
+    ULong64_t externalTS = 0;
+    std::vector<processor_struct::CLOVERS> clover_vec_;
+    std::vector<processor_struct::GAMMASCINT> gamma_scint_vec_;
+    std::vector<processor_struct::VANDLES> vandle_vec_;
+    std::vector<processor_struct::PSPMT> pspmt_vec_;
 
+    ClassDef(PixTreeEvent,1)
 };
-
-struct PSPMT { 
-  ///Contains both low and high gain PSPMT information
-  double xa_l = -999; 
-  double xb_l = -999; 
-  double ya_l = -999; 
-  double yb_l = -999; 
-  double xa_h = -999; 
-  double xb_h = -999; 
-  double ya_h = -999; 
-  double yb_h = -999; 
-  double dy_l = -999;
-  double dy_h = -999;
-  double dyL_time = -999;
-  double dyH_time = -999;
-  double xposL =-999;
-  double yposL =-999;
-  double xposH =-999;
-  double yposH =-999;
-  int anodeLmulti = -999;
-  int anodeHmulti = -999;
-  int dyLmulti = -999;
-  int dyHmulti = -999;
-};
-
 
 #endif //PAASS_PROCESSORSTRUC_HPP

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -21,6 +21,7 @@ struct GAMMASCINT{
     bool HasTrigBeta =false;
     double Energy = -999;
     double RawEnergy = -999;
+    bool IsDynodeOut = false;
     int DetNum = -999;
     double Time = -999;
     double BetaGammaTDiff = -999;

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -11,7 +11,8 @@ struct VANDLES {
     int barNum=0;
     std::string barType="";
     double tdiff=0;
-    double sTime=0;
+    double sTime=0; //start detector time
+    unsigned int sNum =0; //start detector number
     int vMulti=0;
 } ;
 

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -49,5 +49,29 @@ struct CLOVERS{
 
 };
 
+struct PSPMT { 
+  ///Contains both low and high gain PSPMT information
+  double xa_l = -999; 
+  double xb_l = -999; 
+  double ya_l = -999; 
+  double yb_l = -999; 
+  double xa_h = -999; 
+  double xb_h = -999; 
+  double ya_h = -999; 
+  double yb_h = -999; 
+  double dy_l = -999;
+  double dy_h = -999;
+  double dyL_time = -999;
+  double dyH_time = -999;
+  double xposL =-999;
+  double yposL =-999;
+  double xposH =-999;
+  double yposH =-999;
+  int anodeLmulti = -999;
+  int anodeHmulti = -999;
+  int dyLmulti = -999;
+  int dyHmulti = -999;
+};
+
 
 #endif //PAASS_PROCESSORSTRUC_HPP

--- a/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
@@ -60,12 +60,6 @@ public:
         return (make_pair(VDtypeStr,ThreshStr));
     }
 
-    ///@return The vector of the pspmt events for Root output (should only have 1 entry)
-    std::vector<PSPMT> GetPSPMTvector(){
-        return PSvec;
-    }
-
-
 private:
 
     std::pair<double, double> position_low;
@@ -89,8 +83,7 @@ private:
     ///< the Pixie-16 trapezoidal filter needs to reach
     ///< before we can analyze the signals.
 
-    PSPMT PSstruct,DefaultStruc; //!< PSPMT root Struct and Default for reseting
-    std::vector<PSPMT> PSvec; //!<PSPMT vector for root
+    processor_struct::PSPMT PSstruct; //!< PSPMT root Struct
 
     std::string VDtypeStr; //!< VD Type as a string
     std::string ThreshStr; //!< Threshold as a string

--- a/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
@@ -1,6 +1,6 @@
 ///@file PspmtProcessor.cpp
 ///@brief Processes information from a Position Sensitive PMT.
-///@author A. Keeler
+///@author A. Keeler, S. Go, S. V. Paulauskas
 ///@date July 8, 2018
 #ifndef __PSPMTPROCESSOR_HPP__
 #define __PSPMTPROCESSOR_HPP__

--- a/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
@@ -24,7 +24,7 @@ public:
     PspmtProcessor(const std::string &vd, const double &yso_scale,
                    const unsigned int &yso_offset, const double &yso_threshold,
                    const double &front_scale,
-                   const unsigned int &front_offset, const double &front_threshold);
+                   const unsigned int &front_offset, const double &front_threshold, const double &rotation);
 
     ///Default Destructor
     ~PspmtProcessor() {};
@@ -76,7 +76,7 @@ private:
     /// will use to calculate the position.
     ///@return The x,y position of the interaction
     std::pair<double, double> CalculatePosition(double &xa, double &xb, double &ya,
-                                                double &yb, const VDTYPES &vdtype);
+                                                double &yb, const VDTYPES &vdtype, double &rot);
 
 
     VDTYPES vdtype_; ///< Local variable to store the type of voltage divider
@@ -90,6 +90,7 @@ private:
     double front_threshold_; ///< The threshold that the energy calculated by
     ///< the Pixie-16 trapezoidal filter needs to reach
     ///< before we can analyze the signals.
+    double rotation_; ///< rotation angle for Pspmt positions
 
     processor_struct::PSPMT PSstruct; //!< PSPMT root Struct
 

--- a/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
@@ -51,6 +51,8 @@ public:
             return position_low;
         else if (type == "high")
             return position_high;
+        else if (type == "ion_scint")
+            return position_ion;
         else
             return std::pair<double, double>(0., 0.);
     }
@@ -64,6 +66,7 @@ private:
 
     std::pair<double, double> position_low;
     std::pair<double, double> position_high;
+    std::pair<double, double> position_ion;
 
     ///@brief A method to calculate the x position of the interaction with
     /// the scintillator

--- a/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
@@ -21,8 +21,10 @@ public:
     ///@brief Constructor that sets the scale and offset for histograms
     ///@param[in] scale : The multiplicative scaling factor
     ///@param[in] offset : The additave offset for the histogram
-    PspmtProcessor(const std::string &vd, const double &scale,
-                   const unsigned int &offset, const double &threshold);
+    PspmtProcessor(const std::string &vd, const double &yso_scale,
+                   const unsigned int &yso_offset, const double &yso_threshold,
+                   const double &front_scale,
+                   const unsigned int &front_offset, const double &front_threshold);
 
     ///Default Destructor
     ~PspmtProcessor() {};
@@ -80,9 +82,12 @@ private:
     VDTYPES vdtype_; ///< Local variable to store the type of voltage divider
     ///< we're using.
     double positionScale_; ///< The scale that we need for the DAMM output
+    double front_positionScale_; ///< The scale that we need for the DAMM output
     unsigned int positionOffset_; ///< The offset that we need for the the
+    unsigned int front_positionOffset_; ///< The offset that we need for the the
     ///< DAMM output
     double threshold_; ///< The threshold that the energy calculated by
+    double front_threshold_; ///< The threshold that the energy calculated by
     ///< the Pixie-16 trapezoidal filter needs to reach
     ///< before we can analyze the signals.
 

--- a/Analysis/Utkscan/processors/include/SysRootLinkDef.hpp
+++ b/Analysis/Utkscan/processors/include/SysRootLinkDef.hpp
@@ -15,6 +15,9 @@
 #pragma link C++ struct CLOVERS+;
 #pragma link C++ class std::vector<CLOVERS>+;
 
+#pragma link C++ struct PSPMT+;
+#pragma link C++ class std::vector<PSPMT>+;
+
 #endif
 
 #endif //PAASS_LINKDEF_HPP

--- a/Analysis/Utkscan/processors/include/SysRootLinkDef.hpp
+++ b/Analysis/Utkscan/processors/include/SysRootLinkDef.hpp
@@ -1,0 +1,20 @@
+///@file LinkDef.hpp
+///@brief LinkDef for Various ROOT output structures
+///@authors T.T. King
+///@date 2/6/2018
+
+#ifndef PAASS_LINKDEF_HPP
+#define PAASS_LINKDEF_HPP
+#ifdef __CINT__
+#pragma link C++ struct GAMMASCINT+;
+#pragma link C++ class std::vector<GAMMASCINT>+;
+
+#pragma link C++ struct VANDLES+;
+#pragma link C++ class std::vector<VANDLES>+;
+
+#pragma link C++ struct CLOVERS+;
+#pragma link C++ class std::vector<CLOVERS>+;
+
+#endif
+
+#endif //PAASS_LINKDEF_HPP

--- a/Analysis/Utkscan/processors/include/SysRootLinkDef.hpp
+++ b/Analysis/Utkscan/processors/include/SysRootLinkDef.hpp
@@ -1,22 +1,29 @@
-///@file LinkDef.hpp
-///@brief LinkDef for Various ROOT output structures
-///@authors T.T. King
+///@file SysRootLinkDef.hpp
+///@brief SysRootLinkDef for Various ROOT output structures
+///@authors T.T. King, R. Yokoyama
 ///@date 2/6/2018
 
 #ifndef PAASS_LINKDEF_HPP
 #define PAASS_LINKDEF_HPP
 #ifdef __CINT__
-#pragma link C++ struct processor_struct::GAMMASCINT+;
-#pragma link C++ class std::vector<processor_struct::GAMMASCINT>+;
-
-#pragma link C++ struct processor_struct::VANDLES+;
-#pragma link C++ class std::vector<processor_struct::VANDLES>+;
 
 #pragma link C++ struct processor_struct::CLOVERS+;
 #pragma link C++ class std::vector<processor_struct::CLOVERS>+;
 
+#pragma link C++ struct processor_struct::DOUBLEBETA+;
+#pragma link C++ class std::vector<processor_struct::DOUBLEBETA>+;
+
+#pragma link C++ struct processor_struct::GAMMASCINT+;
+#pragma link C++ class std::vector<processor_struct::GAMMASCINT>+;
+
+#pragma link C++ struct processor_struct::LOGIC+;
+#pragma link C++ class std::vector<processor_struct::LOGIC>+;
+
 #pragma link C++ struct processor_struct::PSPMT+;
 #pragma link C++ class std::vector<processor_struct::PSPMT>+;
+
+#pragma link C++ struct processor_struct::VANDLES+;
+#pragma link C++ class std::vector<processor_struct::VANDLES>+;
 
 #pragma link C++ class PixTreeEvent+;
 #pragma link C++ class std::vector<PixTreeEvent>+;

--- a/Analysis/Utkscan/processors/include/SysRootLinkDef.hpp
+++ b/Analysis/Utkscan/processors/include/SysRootLinkDef.hpp
@@ -6,18 +6,20 @@
 #ifndef PAASS_LINKDEF_HPP
 #define PAASS_LINKDEF_HPP
 #ifdef __CINT__
-#pragma link C++ struct GAMMASCINT+;
-#pragma link C++ class std::vector<GAMMASCINT>+;
+#pragma link C++ struct processor_struct::GAMMASCINT+;
+#pragma link C++ class std::vector<processor_struct::GAMMASCINT>+;
 
-#pragma link C++ struct VANDLES+;
-#pragma link C++ class std::vector<VANDLES>+;
+#pragma link C++ struct processor_struct::VANDLES+;
+#pragma link C++ class std::vector<processor_struct::VANDLES>+;
 
-#pragma link C++ struct CLOVERS+;
-#pragma link C++ class std::vector<CLOVERS>+;
+#pragma link C++ struct processor_struct::CLOVERS+;
+#pragma link C++ class std::vector<processor_struct::CLOVERS>+;
 
-#pragma link C++ struct PSPMT+;
-#pragma link C++ class std::vector<PSPMT>+;
+#pragma link C++ struct processor_struct::PSPMT+;
+#pragma link C++ class std::vector<processor_struct::PSPMT>+;
 
+#pragma link C++ class PixTreeEvent+;
+#pragma link C++ class std::vector<PixTreeEvent>+;
 #endif
 
 #endif //PAASS_LINKDEF_HPP

--- a/Analysis/Utkscan/processors/include/VandleProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/VandleProcessor.hpp
@@ -74,12 +74,6 @@ public:
     ///@return true if we requsted large bars in the xml */
     bool GetHasBig(void) { return requestedTypes_.find("big") != requestedTypes_.end(); }
 
-    /**Returns the vector of vandle events. used for coincidence plotting in root
-   *
-   * @return vector of vandle events
-   */
-    std::vector<VANDLES> GetVanVector(){ return VanVec;}
-
 private:
     ///Analyze the data for scenarios with Bar Starts; e.g. Double Beta detectors
     void AnalyzeBarStarts(const BarDetector &bar, unsigned int &barLoc);
@@ -118,8 +112,7 @@ private:
 
     std::set<std::string> requestedTypes_;//!< The list of bar types to expect
 
-    std::vector<VANDLES> VanVec; //!<Vector of vandle events for root
-    VANDLES vandles,DefaultStruct; //!<Working structure and a default one for reseting the values to known 
+    processor_struct::VANDLES vandles; //!<Working structure  
 };
 
 #endif

--- a/Analysis/Utkscan/processors/include/VandleProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/VandleProcessor.hpp
@@ -41,7 +41,8 @@ public:
     ///@param [in] offset : The offset of the DAMM histograms 
     ///@param [in] numStarts : number of starts we have to process */
     VandleProcessor(const std::vector<std::string> &typeList, const double &res, const double &offset,
-                    const unsigned int &numStarts, const double &compression = 1.0);
+                    const unsigned int &numStarts, const double &compression , const double &qdcmin,
+                    const double &tofcut);
 
     ///Preprocess the VANDLE data
     ///@param [in] event : the event to preprocess
@@ -103,6 +104,10 @@ private:
     double plotMult_;//!< The resolution multiplier for DAMM histograms
     double plotOffset_;//!< The offset multiplier for DAMM histograms
     double qdcComp_; //!<QDC compression value as read from the config file
+
+    double qdcmin_;//!<min qdc to add to root tree, used to help speed up nearline mergers etc
+    double tofcut_;//!< min tof to add to root tree for speeding up near line merger
+
 
     bool hasSmall_; //!< True if small bars were requested in the Config
     bool hasBig_; //!< True if big bars were requested in the Config

--- a/Analysis/Utkscan/processors/include/VandleProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/VandleProcessor.hpp
@@ -21,6 +21,8 @@
 #include "EventProcessor.hpp"
 #include "HighResTimingData.hpp"
 
+#include "ProcessorRootStruc.hpp"
+
 /// Class to process VANDLE related events
 class VandleProcessor : public EventProcessor {
 public:
@@ -72,6 +74,12 @@ public:
     ///@return true if we requsted large bars in the xml */
     bool GetHasBig(void) { return requestedTypes_.find("big") != requestedTypes_.end(); }
 
+    /**Returns the vector of vandle events. used for coincidence plotting in root
+   *
+   * @return vector of vandle events
+   */
+    std::vector<VANDLES> GetVanVector(){ return VanVec;}
+
 private:
     ///Analyze the data for scenarios with Bar Starts; e.g. Double Beta detectors
     void AnalyzeBarStarts(const BarDetector &bar, unsigned int &barLoc);
@@ -109,6 +117,9 @@ private:
     unsigned int numStarts_; //!< The number of starts set in the Config File
 
     std::set<std::string> requestedTypes_;//!< The list of bar types to expect
+
+    std::vector<VANDLES> VanVec; //!<Vector of vandle events for root
+    VANDLES vandles,DefaultStruct; //!<Working structure and a default one for reseting the values to known 
 };
 
 #endif

--- a/Analysis/Utkscan/processors/include/VandleProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/VandleProcessor.hpp
@@ -97,8 +97,8 @@ private:
     BarMap barStarts_;//!< A map that holds all of the bar starts
     DetectorSummary *geSummary_;//!< The Detector Summary for Ge Events
 
-    bool hasDecay_; //!< True if there was a correlated beta decay
-    double decayTime_; //!< the time of the decay
+    bool RDecay_; //!< True if there is a rough decay match (no rear veto and no plastic dE)
+
 
     double plotMult_;//!< The resolution multiplier for DAMM histograms
     double plotOffset_;//!< The offset multiplier for DAMM histograms

--- a/Analysis/Utkscan/processors/source/CMakeLists.txt
+++ b/Analysis/Utkscan/processors/source/CMakeLists.txt
@@ -3,9 +3,11 @@ set(PROCESSOR_SOURCES
         BetaScintProcessor.cpp
         DoubleBetaProcessor.cpp
         CloverCalibProcessor.cpp
+        CloverFragProcessor.cpp
         CloverProcessor.cpp
         DssdProcessor.cpp
         EventProcessor.cpp
+        ExtTSSenderProcessor.cpp
         GammaScintProcessor.cpp
         GeProcessor.cpp
         Hen3Processor.cpp
@@ -21,7 +23,6 @@ set(PROCESSOR_SOURCES
         TeenyVandleProcessor.cpp
         TemplateProcessor.cpp
         VandleProcessor.cpp
-        ExtTSSenderProcessor.cpp
         )
 
 if (PAASS_USE_ROOT)

--- a/Analysis/Utkscan/processors/source/CMakeLists.txt
+++ b/Analysis/Utkscan/processors/source/CMakeLists.txt
@@ -6,6 +6,7 @@ set(PROCESSOR_SOURCES
         CloverProcessor.cpp
         DssdProcessor.cpp
         EventProcessor.cpp
+        GammaScintProcessor.cpp
         GeProcessor.cpp
         Hen3Processor.cpp
         ImplantSsdProcessor.cpp
@@ -20,7 +21,8 @@ set(PROCESSOR_SOURCES
         TeenyVandleProcessor.cpp
         TemplateProcessor.cpp
         VandleProcessor.cpp
-        ExtTSSenderProcessor.cpp)
+        ExtTSSenderProcessor.cpp
+        )
 
 if (PAASS_USE_ROOT)
     list(APPEND PROCESSOR_SOURCES RootProcessor.cpp)

--- a/Analysis/Utkscan/processors/source/CMakeLists.txt
+++ b/Analysis/Utkscan/processors/source/CMakeLists.txt
@@ -19,7 +19,8 @@ set(PROCESSOR_SOURCES
         PspmtProcessor.cpp
         TeenyVandleProcessor.cpp
         TemplateProcessor.cpp
-        VandleProcessor.cpp)
+        VandleProcessor.cpp
+        ExtTSSenderProcessor.cpp)
 
 if (PAASS_USE_ROOT)
     list(APPEND PROCESSOR_SOURCES RootProcessor.cpp)

--- a/Analysis/Utkscan/processors/source/CloverFragProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/CloverFragProcessor.cpp
@@ -157,14 +157,11 @@ bool CloverFragProcessor::Process(RawEvent &event) {
 
         if (DetectorDriver::get()->GetSysRootOutput()) {
             //Fill root struct and push back on to vector
-            Cstruct.RawEnergy = (*itClover)->GetEnergy();
-            Cstruct.Energy = gEnergy;
-            Cstruct.Time = (*itClover)->GetTimeSansCfd();
-            Cstruct.HasLowResBeta = isDecay;
-            Cstruct.HasIonTrig = hasIonTrig;
-            Cstruct.HasVeto = hasVeto;
-            Cstruct.DetNum = (*itClover)->GetChanID().GetLocation();
-            Cstruct.CloverNum = cloverNum;
+            Cstruct.rawEnergy = (*itClover)->GetEnergy();
+            Cstruct.energy = gEnergy;
+            Cstruct.time = (*itClover)->GetTimeSansCfd();
+            Cstruct.detNum = (*itClover)->GetChanID().GetLocation();
+            Cstruct.cloverNum = cloverNum;
             pixie_tree_event_->clover_vec_.emplace_back(Cstruct);
             Cstruct = processor_struct::CLOVERS_DEFAULT_STRUCT; //reset to initalized values (see ProcessorRootStruc.hpp
         }

--- a/Analysis/Utkscan/processors/source/CloverFragProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/CloverFragProcessor.cpp
@@ -155,19 +155,19 @@ bool CloverFragProcessor::Process(RawEvent &event) {
             plot(D_CLOVERFRAG_ENERGY_ANTIVETO,gEnergy);
         }
 
-
-        //Fill root struct and push back on to vector
-        Cstruct.RawEnergy = (*itClover)->GetEnergy();
-        Cstruct.Energy = gEnergy;
-        Cstruct.Time = (*itClover)->GetTimeSansCfd();
-        Cstruct.HasLowResBeta = isDecay;
-        Cstruct.HasIonTrig = hasIonTrig;
-        Cstruct.HasVeto = hasVeto;
-        Cstruct.DetNum = (*itClover)->GetChanID().GetLocation();
-        Cstruct.CloverNum = cloverNum;
-        pixie_tree_event_->clover_vec_.emplace_back(Cstruct);
-        Cstruct = processor_struct::CLOVERS_DEFAULT_STRUCT; //reset to initalized values (see ProcessorRootStruc.hpp
-
+        if (DetectorDriver::get()->GetSysRootOutput()) {
+            //Fill root struct and push back on to vector
+            Cstruct.RawEnergy = (*itClover)->GetEnergy();
+            Cstruct.Energy = gEnergy;
+            Cstruct.Time = (*itClover)->GetTimeSansCfd();
+            Cstruct.HasLowResBeta = isDecay;
+            Cstruct.HasIonTrig = hasIonTrig;
+            Cstruct.HasVeto = hasVeto;
+            Cstruct.DetNum = (*itClover)->GetChanID().GetLocation();
+            Cstruct.CloverNum = cloverNum;
+            pixie_tree_event_->clover_vec_.emplace_back(Cstruct);
+            Cstruct = processor_struct::CLOVERS_DEFAULT_STRUCT; //reset to initalized values (see ProcessorRootStruc.hpp
+        }
     }
     EndProcess();
     return true;

--- a/Analysis/Utkscan/processors/source/CloverFragProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/CloverFragProcessor.cpp
@@ -1,0 +1,232 @@
+/** @file CloverFragProcessor.cpp
+ *  @brief Processor for Clovers at Fragmentation Facilities (Based HEAVILY on CloverProcessor.cpp)
+ *  @authors T.T. King
+ *  @date Nov 2018
+*/
+
+#include <algorithm>
+#include <cstdlib>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <set>
+#include <sstream>
+
+#include "pugixml.hpp"
+
+#include "DammPlotIds.hpp"
+#include "DetectorDriver.hpp"
+#include "DetectorLibrary.hpp"
+#include "Display.h"
+#include "Exceptions.hpp"
+#include "Messenger.hpp"
+#include "RawEvent.hpp"
+#include "CloverFragProcessor.hpp"
+
+using namespace std;
+using namespace dammIds::cloverFrag;
+
+namespace dammIds {
+    //! Namespace containing histogram definitions for the Clover. We are overriding the CloverProcessor space so the processors are exclusive
+    namespace cloverFrag {
+        const unsigned int MAX_FRAGCLOVERS = 4; //!< for *_DETX spectra
+
+        const int D_CLOVERFRAG_ENERGY = 0;//!< Energy
+        const int D_CLOVERFRAG_ENERGY_CLOVERX = 2; //!< Energy Full Clover
+        const int D_CLOVERFRAG_MULTI = 9; //!<Multiplicity
+        const int D_CLOVERFRAG_ENERGY_DECAY = 10; //!<Rough Decay Gated Energy
+        const int D_CLOVERFRAG_ENERGY_IMPLANT = 11; //!<Rough IMPLANT Gated Energy
+        const int D_CLOVERFRAG_ENERGY_ANTIVETO = 12; //!<Anti veto Gated Energy
+
+
+    } // end namespace clover
+}
+
+
+
+CloverFragProcessor::CloverFragProcessor(double gammaThreshold, double vetoThresh, double ionTrigThresh, double betaThresh) : EventProcessor(OFFSET,RANGE,"CloverFragProcessor") {
+    associatedTypes.insert("clover");
+
+    gammaThresh_ = gammaThreshold;
+    vetoThresh_ = vetoThresh;
+    ionTrigThresh_ = ionTrigThresh;
+    betaThresh_ = betaThresh;
+
+
+}
+
+/** Declare plots including many for decay/implant/neutron gated analysis  */
+void CloverFragProcessor::DeclarePlots(void) {
+    const int energyBins1 = SD;
+
+    //build the clovers from the channel list
+    auto cloverLocs_ = DetectorLibrary::get()->GetLocations("clover", "clover_high");
+    CloverBuilder(cloverLocs_);
+
+    DeclareHistogram1D(D_CLOVERFRAG_ENERGY, energyBins1, "Ungated Clover Singles");
+    DeclareHistogram1D(D_CLOVERFRAG_MULTI, S5, "Clover Multiplicity");
+    DeclareHistogram1D(D_CLOVERFRAG_ENERGY_DECAY,energyBins1, "Rough Decay Gated Clover Singles");
+    DeclareHistogram1D(D_CLOVERFRAG_ENERGY_IMPLANT,energyBins1, "Rough Implant Gated Clover Singles");
+    DeclareHistogram1D(D_CLOVERFRAG_ENERGY_ANTIVETO,energyBins1, "Anti-Gated on Veto Clover Singles");
+
+
+    // for each clover
+    for (unsigned int i = 0; i < numClovers; i++) {
+        stringstream ss;
+        ss << "Clover " << i << " gamma";
+        DeclareHistogram1D(D_CLOVERFRAG_ENERGY_CLOVERX + i, energyBins1, ss.str().c_str());
+    }
+
+}
+
+bool CloverFragProcessor::PreProcess(RawEvent &event) {
+    if (!EventProcessor::PreProcess(event))
+        return false;
+
+
+    return true;
+}
+
+bool CloverFragProcessor::Process(RawEvent &event) {
+    using namespace dammIds::cloverFrag;
+
+    if (!EventProcessor::Process(event))
+        return false;
+
+    //vector <ChanEvent*>
+    static const auto &cloverEvents = event.GetSummary("clover:clover_high",true)->GetList();
+    static const auto &vetoEvents = event.GetSummary("pspmt:veto",true)->GetList();
+    static const auto &ionTriggerEvents = event.GetSummary("pspmt:ion",true)->GetList();
+    static const auto &pspmtBetaEvents = event.GetSummary("pspmt:dynode_high",true)->GetList();
+
+    // loop through gater events for either light ion veto (behind) or ion trigger (in front)
+    // the Ion trigger allows for beam diagnositcs though beam produced isomers
+    // light ion veto will trigger with punch throughs (C, P+, alphas etc)
+    //pspmt beta signal
+
+    bool hasVeto = false;
+    bool hasIonTrig =false;
+    bool hasPspmtBeta = false;
+
+    for (auto itVeto = vetoEvents.begin(); itVeto!= vetoEvents.end();itVeto++){
+        if ((*itVeto)->GetCalibratedEnergy() >= vetoThresh_ )
+            hasVeto = true;
+    };
+
+    for (auto itIon = ionTriggerEvents.begin(); itIon!= ionTriggerEvents.end(); itIon++){
+        if ((*itIon)->GetCalibratedEnergy() >= ionTrigThresh_)
+            hasIonTrig = true;
+    };
+
+    for (auto itPbeta= pspmtBetaEvents.begin(); itPbeta!= pspmtBetaEvents.end(); itPbeta++){
+        if ((*itPbeta)->GetCalibratedEnergy() >= betaThresh_)
+            hasPspmtBeta = true;
+    };
+    // end gater loops
+
+    // start loop over clover events (start with multiplicity plot)
+    plot(D_CLOVERFRAG_MULTI,cloverEvents.size());
+
+    for (auto itClover = cloverEvents.begin(); itClover != cloverEvents.end(); itClover++){
+        double gEnergy = (*itClover)->GetCalibratedEnergy();
+        int cloverNum= leafToClover[(*itClover)->GetChanID().GetLocation()];
+
+        if (gEnergy < gammaThresh_)
+            continue;
+
+        //we call it a "decay" if we dont have a veto or ionTrigger and we have a pspmt:dynode_high
+        bool isDecay = false;
+        if (!hasIonTrig && !hasVeto && hasPspmtBeta ) {
+            isDecay = true;
+        }
+
+        plot(D_CLOVERFRAG_ENERGY,gEnergy);
+        plot(D_CLOVERFRAG_ENERGY_CLOVERX + cloverNum,gEnergy);
+
+        if (isDecay){
+            plot(D_CLOVERFRAG_ENERGY_DECAY,gEnergy);
+        }
+        if (hasIonTrig){
+            plot(D_CLOVERFRAG_ENERGY_IMPLANT,gEnergy);
+        }
+        if (!hasVeto){
+            plot(D_CLOVERFRAG_ENERGY_ANTIVETO,gEnergy);
+        }
+
+
+        //Fill root struct and push back on to vector
+        Cstruct.RawEnergy = (*itClover)->GetEnergy();
+        Cstruct.Energy = gEnergy;
+        Cstruct.Time = (*itClover)->GetTimeSansCfd();
+        Cstruct.HasLowResBeta = isDecay;
+        Cstruct.HasIonTrig = hasIonTrig;
+        Cstruct.HasVeto = hasVeto;
+        Cstruct.DetNum = (*itClover)->GetChanID().GetLocation();
+        Cstruct.CloverNum = cloverNum;
+        pixie_tree_event_->clover_vec_.emplace_back(Cstruct);
+        Cstruct = processor_struct::CLOVERS_DEFAULT_STRUCT; //reset to initalized values (see ProcessorRootStruc.hpp
+
+    }
+    EndProcess();
+    return true;
+}
+
+
+void CloverFragProcessor::CloverBuilder(const std::set<int> &cloverLocs) {
+
+    /*  clover specific routine, determine the number of clover detector
+       channels and divide by num of chans per clover to find the total number of clovers
+       ORNL clovers are 4
+    */
+    auto cloverLocations = &cloverLocs;
+    // could set it now but we'll iterate through the locations to set this
+    unsigned int cloverChans = 0;
+
+    for (set<int>::const_iterator it = cloverLocations->begin(); it != cloverLocations->end(); it++) {
+        leafToClover[*it] = int(cloverChans / chansPerClover);
+        cloverChans++;
+    }
+
+    if (cloverChans % chansPerClover != 0) {
+        stringstream ss;
+        ss << " There does not appear to be the proper number of"
+           << " channels per clover.";
+        throw GeneralException(ss.str());
+    }
+    if (cloverChans != 0) {
+        numClovers = cloverChans / chansPerClover;
+        Messenger m;
+        m.start("Building clovers");
+
+        stringstream ss;
+        ss << "A total of " << cloverChans
+           << " clover channels were detected: ";
+        int lastClover = numeric_limits<int>::min();
+        for (map<int, int>::const_iterator it = leafToClover.begin();
+             it != leafToClover.end(); it++) {
+            if (it->second != lastClover) {
+                m.detail(ss.str());
+                ss.str("");
+                lastClover = it->second;
+                ss << "Clover " << lastClover << " : ";
+            } else {
+                ss << ", ";
+            }
+            ss << setw(2) << it->first;
+        }
+        m.detail(ss.str());
+
+        if (numClovers > dammIds::cloverFrag::MAX_FRAGCLOVERS) {
+            m.fail();
+            stringstream ss;
+            ss << "Number of detected clovers is greater than defined"
+               << " MAX_CLOVERS = " << dammIds::cloverFrag::MAX_FRAGCLOVERS << "."
+               << " See CloverProcessor.hpp for details.";
+            throw GeneralException(ss.str());
+        }
+        m.done();
+    }
+
+}

--- a/Analysis/Utkscan/processors/source/CloverProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/CloverProcessor.cpp
@@ -525,18 +525,15 @@ bool CloverProcessor::Process(RawEvent &event) {
             plot(betaGated::D_NONCYCGATEDENERGY, gEnergy);
             double gTime = itC->GetTimeSansCfd();
             EventData bestBeta = BestBetaForGamma(gTime);
-            Cstruct.BetaCloverTDiff = (gTime - bestBeta.time) * clockInSeconds *1.e9;
-            Cstruct.BetaEnergy = bestBeta.energy;
-            Cstruct.BetaTime = bestBeta.time;
         }
+
         plot(D_NONCYCGATEDENERGY, gEnergy);
-        Cstruct.RawEnergy = itC->GetEnergy();
-        Cstruct.Energy = itC->GetCalibratedEnergy();
-        Cstruct.Time = itC->GetTimeSansCfd();
-        Cstruct.LastCycleTime = cycleTime;
-        Cstruct.HasLowResBeta = hasBeta;
-        Cstruct.DetNum = itC->GetChanID().GetLocation();
-        Cstruct.CloverNum = leafToClover[itC->GetChanID().GetLocation()];
+
+        Cstruct.rawEnergy = itC->GetEnergy();
+        Cstruct.energy = itC->GetCalibratedEnergy();
+        Cstruct.time = itC->GetTimeSansCfd();
+        Cstruct.detNum = itC->GetChanID().GetLocation();
+        Cstruct.cloverNum = leafToClover[itC->GetChanID().GetLocation()];
         pixie_tree_event_->clover_vec_.emplace_back(Cstruct);
         Cstruct = processor_struct::CLOVERS_DEFAULT_STRUCT; //reset to initalized values (see ProcessorRootStruc.hpp
 

--- a/Analysis/Utkscan/processors/source/CloverProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/CloverProcessor.cpp
@@ -523,6 +523,11 @@ bool CloverProcessor::Process(RawEvent &event) {
             continue;
         if (hasBeta) {
             plot(betaGated::D_NONCYCGATEDENERGY, gEnergy);
+            double gTime = itC->GetTimeSansCfd();
+            EventData bestBeta = BestBetaForGamma(gTime);
+            Cstruct.BetaCloverTDiff = (gTime - bestBeta.time) * clockInSeconds *1.e9;
+            Cstruct.BetaEnergy = bestBeta.energy;
+            Cstruct.BetaTime = bestBeta.time;
         }
         plot(D_NONCYCGATEDENERGY, gEnergy);
         Cstruct.RawEnergy = itC->GetEnergy();
@@ -536,7 +541,7 @@ bool CloverProcessor::Process(RawEvent &event) {
         Cstruct = processor_struct::CLOVERS_DEFAULT_STRUCT; //reset to initalized values (see ProcessorRootStruc.hpp
 
         //Dont fill because we want 1 pixie event per tree entry, so we add the current structure in the last spot
-        //on a vector<> and then reset the structure. and we will at the end or Process()
+        //on a vector<> and then reset the structure. and we will at the end of Process()
     }
 
 

--- a/Analysis/Utkscan/processors/source/CloverProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/CloverProcessor.cpp
@@ -458,12 +458,11 @@ bool CloverProcessor::PreProcess(RawEvent &event) {
         // entries in map are sorted by time
         // if event time is outside of subEventWindow, we start new
         //   events for all clovers and "tas"
-        double dtime =
-                abs(time - refTime) * Globals::get()->GetClockInSeconds();
+        double dtime =  abs(time - refTime) * Globals::get()->GetClockInSeconds();
         if (dtime > subEventWindow_) {
             for (unsigned i = 0; i < numClovers; ++i) {
                 addbackEvents_[i].push_back(AddBackEvent());
-                addbackEvents_[clover].back().ftime = time* Globals::get()->GetClockInSeconds()*1.e9;
+                addbackEvents_[i].back().time = time* Globals::get()->GetClockInSeconds()*1.e9;
             }
             tas_.push_back(AddBackEvent());
         }
@@ -482,7 +481,7 @@ bool CloverProcessor::PreProcess(RawEvent &event) {
 }
 
 bool CloverProcessor::Process(RawEvent &event) {
-    using namespace dammIds::ge;
+    using namespace dammIds::clover;
 
     if (!EventProcessor::Process(event))
         return false;

--- a/Analysis/Utkscan/processors/source/CloverProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/CloverProcessor.cpp
@@ -394,7 +394,6 @@ bool CloverProcessor::PreProcess(RawEvent &event) {
         return false;
 
     geEvents_.clear();
-    Csing.clear();
     for (unsigned i = 0; i < numClovers; ++i)
         addbackEvents_[i].clear();
     tas_.clear();
@@ -533,8 +532,8 @@ bool CloverProcessor::Process(RawEvent &event) {
         Cstruct.HasLowResBeta = hasBeta;
         Cstruct.DetNum = itC->GetChanID().GetLocation();
         Cstruct.CloverNum = leafToClover[itC->GetChanID().GetLocation()];
-        Csing.emplace_back(Cstruct);
-        Cstruct=DefaultStruct; //reset to initalized values (see ProcessorRootStruc.hpp
+        pixie_tree_event_->clover_vec_.emplace_back(Cstruct);
+        Cstruct = processor_struct::CLOVERS_DEFAULT_STRUCT; //reset to initalized values (see ProcessorRootStruc.hpp
 
         //Dont fill because we want 1 pixie event per tree entry, so we add the current structure in the last spot
         //on a vector<> and then reset the structure. and we will at the end or Process()

--- a/Analysis/Utkscan/processors/source/ExtTSSenderProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/ExtTSSenderProcessor.cpp
@@ -6,6 +6,7 @@ slotNum_(0),
 chanNum_(0),
 port_(12345),
 hostName_("localhost"),
+buffer_(nullptr),
 buffSize_(64),
 curPos_(0)
 {
@@ -14,7 +15,14 @@ curPos_(0)
 
 ExtTSSenderProcessor::ExtTSSenderProcessor(const std::string &type, const std::string &hostName,
                                            const int &slot, const int &channel, const int &port, const int &buffSize) :
-EventProcessor(7998, 1, "ExtTSSenderProcessor")
+EventProcessor(7998, 1, "ExtTSSenderProcessor"),
+slotNum_(0),
+chanNum_(0),
+port_(12345),
+hostName_("localhost"),
+buffer_(nullptr),
+buffSize_(64),
+curPos_(0)
 {
     type_ = type;
     slotNum_ = slot;

--- a/Analysis/Utkscan/processors/source/ExtTSSenderProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/ExtTSSenderProcessor.cpp
@@ -1,0 +1,100 @@
+#include "ChanEvent.hpp"
+#include "ExtTSSenderProcessor.hpp"
+
+ExtTSSenderProcessor::ExtTSSenderProcessor() : EventProcessor(7998, 1, "ExtTSSenderProcessor"),
+type_("pspmt:dynode"),
+tag_("beta"),
+port_(12345),
+hostName_("localhost"),
+buffSize_(64),
+curPos_(0)
+{
+    Init(hostName_, port_); 
+}
+
+ExtTSSenderProcessor::ExtTSSenderProcessor(const std::string &type, const std::string &hostName,
+                                           const std::string &tag, const int &port, const int &buffSize) :
+EventProcessor(7998, 1, "ExtTSSenderProcessor")
+{
+    type_ = type;
+    tag_ = tag;
+    buffSize_ = buffSize;
+    Init(hostName, port); 
+}
+
+ExtTSSenderProcessor::~ExtTSSenderProcessor()
+{
+    SendTS();
+    Close();
+    if(udpClient_) delete udpClient_;
+    if(buffer_) delete buffer_;
+}
+  
+bool ExtTSSenderProcessor::Process(RawEvent &event)
+{
+    if (!EventProcessor::Process(event))
+        return false;
+
+    static const std::vector<ChanEvent *> &chEvents = event.GetSummary(type_)->GetList();
+ 
+    for( auto chEvent : chEvents ) {
+        if( chEvent->GetChanID().HasTag(tag_) || !tag_.length() ){
+            unsigned long long int ts_ = (unsigned long long int)chEvent->GetExternalTimeStamp();
+            SetTS(ts_);
+        }
+    }
+    
+    EndProcess();
+    return true;
+}
+
+void ExtTSSenderProcessor::SetBuffSize(const unsigned int &buffSize)
+{
+    if(buffer_)
+      delete buffer_;
+    buffer_ = new unsigned long long int[buffSize];
+
+    ClearBuff();
+
+    buffSize_ = buffSize;
+
+}
+
+bool ExtTSSenderProcessor::Init(const std::string &hostName, const int &port)
+{
+    associatedTypes.insert(type_);
+
+    hostName_ = hostName;
+    port_ = port;
+
+    udpClient_ = new Client();
+    SetBuffSize(buffSize_);
+
+    return udpClient_->Init(hostName_.c_str(),port_);
+}
+
+int ExtTSSenderProcessor::SendTS()
+{
+    return udpClient_->SendMessage((char*)buffer_,8*buffSize_);
+}
+
+void ExtTSSenderProcessor::SetTS(const unsigned long long int &ts)
+{
+    buffer_[curPos_] = ts;
+    curPos_++;
+
+    if(curPos_ >= buffSize_){
+      SendTS();
+      ClearBuff();
+    }
+
+}
+
+void ExtTSSenderProcessor::ClearBuff()
+{
+    for(unsigned int i=0; i<buffSize_; i++){
+      buffer_[i] = 0;
+    }
+    curPos_ = 0;
+}
+  

--- a/Analysis/Utkscan/processors/source/ExtTSSenderProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/ExtTSSenderProcessor.cpp
@@ -9,7 +9,7 @@ hostName_("localhost"),
 buffSize_(64),
 curPos_(0)
 {
-    Init(hostName_, port_); 
+    Init(hostName_, port_);
 }
 
 ExtTSSenderProcessor::ExtTSSenderProcessor(const std::string &type, const std::string &hostName,
@@ -20,7 +20,7 @@ EventProcessor(7998, 1, "ExtTSSenderProcessor")
     slotNum_ = slot;
     chanNum_ = channel;
     buffSize_ = buffSize;
-    Init(hostName, port); 
+    Init(hostName, port);
     associatedTypes.insert(type_);
 }
 
@@ -31,21 +31,21 @@ ExtTSSenderProcessor::~ExtTSSenderProcessor()
     if(udpClient_) delete udpClient_;
     if(buffer_) delete buffer_;
 }
-  
+
 bool ExtTSSenderProcessor::Process(RawEvent &event)
 {
     if (!EventProcessor::Process(event))
         return false;
 
     static const std::vector<ChanEvent *> &chEvents = event.GetEventList();
- 
     for( auto chEvent : chEvents ) {
         if( chEvent->GetChannelNumber() == chanNum_ && chEvent->GetModuleNumber() == slotNum_ ){
-            unsigned long long int ts_ = (unsigned long long int)chEvent->GetExternalTimeStamp();
-            SetTS(ts_);
+            unsigned long long ts = chEvent->GetExternalTimeStamp();
+            // printf("ts %llu \n", ts);
+            SetTS(ts);
         }
     }
-    
+
     EndProcess();
     return true;
 }
@@ -97,4 +97,3 @@ void ExtTSSenderProcessor::ClearBuff()
     }
     curPos_ = 0;
 }
-  

--- a/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
@@ -229,9 +229,6 @@ bool GammaScintProcessor::Process(RawEvent &event) {
     if (!EventProcessor::Process(event))
         return (false);
 
-    if (SysRoot_) {
-        PEsing.clear(); // Clearing root output vector
-    }
     hasLowResBeta_ = false;
     hasMedResBeta_ = false;
 
@@ -388,8 +385,8 @@ bool GammaScintProcessor::Process(RawEvent &event) {
             Gsing.BunchNum = bunchNum_;
             Gsing.LastBunchTime = bunchLast_;
             Gsing.DetNum = (*it)->GetChanID().GetLocation();
-            PEsing.emplace_back(Gsing);
-            Gsing=DefaultStruct; //reset structure
+            pixie_tree_event_->gamma_scint_vec_.emplace_back(Gsing);
+            Gsing = processor_struct::GAMMASCINT_DEFAULT_STRUCT; //reset structure
             //Dont fill because we want 1 pixie event per tree entry, so we add the current structure in the last spot
             //on a vector<> and then reset the structure. and we will at the end or Process()
         } //end sysroot_

--- a/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
@@ -357,7 +357,6 @@ bool GammaScintProcessor::Process(RawEvent &event) {
                 Group = (*it)->GetChanID().GetTags().begin()->c_str();; //only adds the first Tag as the grouping. @TODO to be fixed for any order or # of tags
                 Gsing.NumGroup = Group.back(); //gets last character of the group string for the number
             }else {
-               Group = "N/A";
                 Gsing.NumGroup = -1; //store -1 for the group num if it isnt set
            }
             //root has issues with the strings in the PEsing Vector -> NumGroup (above )and NumType (here)
@@ -373,14 +372,11 @@ bool GammaScintProcessor::Process(RawEvent &event) {
                 Gsing.NumType = -1;
 
             Gsing.HasTrigBeta = hasTrigBeta_;
-            Gsing.Group = Group;
             Gsing.LastBunchTime = bunchLast_;
             Gsing.Energy = Genergy;
             Gsing.RawEnergy = (*it)->GetEnergy();
-            Gsing.Type = subType;
             Gsing.Time = Gtime;
             Gsing.HasLowResBeta = hasLowResBeta_;
-            Gsing.BetaMulti = BetaList.size();
             Gsing.EvtNum = evtNum_;
             Gsing.BunchNum = bunchNum_;
             Gsing.LastBunchTime = bunchLast_;

--- a/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
@@ -64,8 +64,9 @@ void GammaScintProcessor::DeclarePlots() {
         ss << typeName << " Beta-Gated Energy";
         DeclareHistogram1D(D_BGENERGY + offset, SE, ss.str().c_str());
 
+        ss.str("");
         ss << typeName << "Energy from Dynode (totals)";
-        DeclareHistogram1D(D_ENERGY + offset, SD, ss.str().c_str());
+        DeclareHistogram1D(D_DYENERGY + offset, SD, ss.str().c_str());
 
         ss.str("");
         ss<< typeName << "Addback Energy";

--- a/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
@@ -45,7 +45,7 @@ namespace dammIds {
 using namespace std;
 using namespace dammIds::gscint;
 
-GammaScintProcessor::~GammaScintProcessor(){}
+GammaScintProcessor::~GammaScintProcessor()=default;
 
 void GammaScintProcessor::DeclarePlots() {
     for(auto it= typeList_.begin(); it != typeList_.end(); it++) {
@@ -313,18 +313,14 @@ bool GammaScintProcessor::Process(RawEvent &event) {
             //loop the the "beta" events to find the current gamma event's closest beta event
             //For the ORNL2016 data the beta multiplicy is mostly 1 so this is here for completeness and
             //the possiblity of a future need.
-            for (auto it = BetaList.begin(); it != BetaList.end(); it++) {
-                double BetaTime =(*it).first * Globals::get()->GetClockInSeconds() * 1.e9;
-                double MRBtDiff =  BetaTime - Gtime;
+
+            for (auto itB = BetaList.begin(); itB != BetaList.end(); itB++) {
+                double BetaTime =(*itB).first * Globals::get()->GetClockInSeconds() * 1.e9;
+                double MRBtDiff = Gtime - BetaTime ;
                 if (MRBtDiff < 0)
                     continue;
                 else if (MRBtDiff >= 0)   {
                     hasMedResBeta_ = true;
-                    if (SysRoot_) {
-                        Gsing.BetaEnergy = (*it).second;
-                        Gsing.BetaGammaTDiff = MRBtDiff;
-                        Gsing.BetaTime = BetaTime;
-                    }
                     break;
                 }
             }// end BetaList Loop
@@ -346,11 +342,11 @@ bool GammaScintProcessor::Process(RawEvent &event) {
         }
 
         if (SysRoot_) {
-            if (((*it)->GetChanID().HasTag("dy"))) {
-                Gsing.IsDynodeOut = true;
-            } else{
-                Gsing.IsDynodeOut = false;
-            }
+
+
+            if ((*it)->GetChanID().HasTag("dy"))
+                Gsing.isDynodeOut = true;
+
             std::string Group;
             if (!(*it)->GetChanID().GetTags().empty()) {
                 //Group and NumGroup NEED protection from empty sets/strings, but this should be taken care of by the above IF()
@@ -371,16 +367,11 @@ bool GammaScintProcessor::Process(RawEvent &event) {
             else
                 Gsing.NumType = -1;
 
-            Gsing.HasTrigBeta = hasTrigBeta_;
-            Gsing.LastBunchTime = bunchLast_;
-            Gsing.Energy = Genergy;
-            Gsing.RawEnergy = (*it)->GetEnergy();
-            Gsing.Time = Gtime;
-            Gsing.HasLowResBeta = hasLowResBeta_;
-            Gsing.EvtNum = evtNum_;
-            Gsing.BunchNum = bunchNum_;
-            Gsing.LastBunchTime = bunchLast_;
-            Gsing.DetNum = (*it)->GetChanID().GetLocation();
+
+            Gsing.energy = Genergy;
+            Gsing.rawEnergy = (*it)->GetEnergy();
+            Gsing.time = Gtime;
+            Gsing.detNum = (*it)->GetChanID().GetLocation();
             pixie_tree_event_->gamma_scint_vec_.emplace_back(Gsing);
             Gsing = processor_struct::GAMMASCINT_DEFAULT_STRUCT; //reset structure
             //Dont fill because we want 1 pixie event per tree entry, so we add the current structure in the last spot

--- a/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
@@ -1,0 +1,516 @@
+/** \file GammaScintProcessor.cpp
+ *\brief Processes information for Scintillation Type Gamma Detectors
+ *
+ *Processes information from scintillation type gamma-ray detectors. This code should function similarly to the clover
+ * processor.
+ *
+ * The PROOF compatible root output requires that you load the pixieSuite environment module ($installDir/share/modulefiles/)
+ * or you will get errors at runtime from root. Suggestions on a fix are welcome. If you do not set the Root4AB option in
+ * the CFG you can ignore this.
+ *
+ *\author T. T. King
+ *\date 21 Dec 2017
+ */
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+
+#include "BarDetector.hpp"
+#include "DetectorDriver.hpp"
+#include "DoubleBetaProcessor.hpp"
+#include "GammaScintProcessor.hpp"
+#include "RawEvent.hpp"
+
+
+
+namespace dammIds {
+    namespace gscint{
+        const int LITTLEHAG_OFFSET = 0; //!< offset for 2" hagrid
+        const int BIGHAG_OFFSET = 20; //!< offset for 3" hagrid
+        const int NaIOFFSET = 30; //!< offset for the Nai:beasts
+        const int ADDBACKOFFSET = 100; //!< offset for addback Spectra
+        const int GAMMAGAMMAOFFSET = 150;//!< offset for the beta-gamma->gamma plots
+
+        const int D_ENERGY = 0; //!< Energy "Totals" (all det of a single kind in 1 plot)
+        const int D_BGENERGY = 1; //!< Event Beta-Gated "Totals"
+        const int D_MBGENERGY = 2; //!< Medium Resolution Beta-Gated "Totals"
+        const int D_CYCLEENERGY = 4; //!< Totals anti-gated on TapeMove
+        const int DD_MULTI = 5; //!< Multiplicy (normal, betaGated)
+        const int DD_LONGTIME_ENERGY = 6 ; //!< Energy vs Time (Bunched) (Used for Tracking Drift over Long Times)
+        const int DD_TIME_ENERGY = 7; //!< Energy vs Short Time (only uses the first Scale)
+        const int DD_BGTIME_ENERGY = 8; //!< Beta Gated Energy vs Time (Used for prompt vs delayed gammas)
+
+    }
+}//namespace dammIds
+
+using namespace std;
+using namespace dammIds::gscint;
+
+GammaScintProcessor::~GammaScintProcessor(){}
+
+void GammaScintProcessor::DeclarePlots() {
+    for(auto it= typeList_.begin(); it != typeList_.end(); it++) {
+        unsigned int offset = ReturnOffset((*it));
+        if (offset == numeric_limits<unsigned int>::max()) {
+            throw GeneralException("UNKNOWN Gamma Detector Type. Known Types are nai, smallhag, bighag");
+        }
+
+        const string typeName = (*it);
+        stringstream ss;
+
+        ss << typeName << "Energy (totals)";
+        DeclareHistogram1D(D_ENERGY + offset, SD, ss.str().c_str());
+
+        ss.str("");
+        ss<< typeName << "Addback Energy";
+        DeclareHistogram1D(D_ENERGY + offset + ADDBACKOFFSET, SD, ss.str().c_str());
+
+        ss.str("");
+        ss << typeName << " Beta-Gated Energy";
+        DeclareHistogram1D(D_BGENERGY + offset, SE, ss.str().c_str());
+
+        ss.str("");
+        ss<< typeName << "BG Addback Energy";
+        DeclareHistogram1D(D_BGENERGY + offset + ADDBACKOFFSET, SD, ss.str().c_str());
+
+        ss.str("");
+        ss << typeName << " Med Res Beta-Gated Energy (" << MRBetaWindow_.second << "ns)";
+        DeclareHistogram1D(D_MBGENERGY + offset, SE, ss.str().c_str());
+
+        if (ISOL_){
+            ss.str("");
+            ss << typeName << " Energy (Anti-Tape Move)";
+            DeclareHistogram1D(D_CYCLEENERGY + offset, SE, ss.str().c_str());
+        }
+
+        ss.str("");
+        ss<<typeName << " Multiplicity (Normal,BetaGated)";
+        DeclareHistogram2D(DD_MULTI + offset,S6,S3,ss.str().c_str());
+
+
+        ss.str("");
+        ss<<typeName << " <E> vs T (Drift Tracker) " << FacilType_;
+        DeclareHistogram2D(DD_LONGTIME_ENERGY + offset,SE,SB,ss.str().c_str());
+        // SB: this gives 2048 cycles for ISOL and a bit more than 16 hours (with 30 sec bunches) for fragmentation
+
+        if (EvsT_) {
+            //this bool is here because these are LARGE (with binDepth = 2) his, they add ~1GB to the .his file size, for the SINGLE DEFAULT
+            //time scale. default parse is True
+            ss.str("");
+            ss << typeName << " <E> vs Short T";
+            DeclareHistogramTimeY(DD_TIME_ENERGY + offset, SD, SD, ss.str().c_str(), binDepth, timeScales_.front(), "s");
+
+            ss.str("");
+            ss << typeName << " BG <E> vs Short Time";
+            DeclareHistogramTimeY(DD_BGTIME_ENERGY + offset, SD, SD, ss.str().c_str(), binDepth, timeScales_, "s");
+
+        }
+        if (BetaGammGamm) {
+            Messenger m;
+            m.detail("Loading Beta Gamma-gamma Plots from GammaScintProcessor", 1);
+            /**@todo add beta gamma gamma plots
+             */
+        }
+    }
+}
+
+
+GammaScintProcessor::GammaScintProcessor(const std::map<std::string,std::string> &GSArgs,
+                                         const std::vector<std::string> &DetTypes,
+                                         const std::vector<std::string> &TimeScales)
+        :EventProcessor(OFFSET,RANGE, "GammaScintProcessor"){
+
+    Theader = GSArgs;
+    associatedTypes.insert("gscint");
+
+    ISOL_=false;
+    FacilType_ = GSArgs.find("FacilityType")->second;
+    if (FacilType_ =="ISOL")
+        ISOL_ = true;
+
+    typeList_= set<string>(DetTypes.begin(),DetTypes.end());
+    EvsT_ = StringManipulation::StringToBool(GSArgs.find("EnergyVsTime")->second);
+
+
+    if (ISOL_){
+        BunchingTimestr_ = "Tape_Cycle";
+        bunchingTime_ = (double) 0.0;
+    }else {
+        BunchingTimestr_ = GSArgs.find("BunchingTime")->second;
+        bunchingTime_ = strtod(BunchingTimestr_.c_str(), nullptr);
+    }
+
+    SysRoot_ =  StringManipulation::StringToBool(GSArgs.find("DDroot")->second);
+
+    if (!TimeScales.empty()) {
+        if (TimeScales.size() > MAXTIMEPLOTS)
+            throw GeneralException("Requested more Time Scale plots than allowed. "
+                                           "Check GammaScintProcessor.hpp for details");
+        timeScales_.emplace_back(10e-3);
+        //Robert and Miguel agreed that 10ms should A) be default, and B) should always be present if we ask for these.
+        for (auto it = TimeScales.begin(); it != TimeScales.end(); it++) {
+            stringstream ss;
+            ss << (*it) << "e-3";
+            timeScales_.emplace_back(strtof(ss.str().c_str(), nullptr));
+        }
+    }else {
+        timeScales_.emplace_back(10e-3);
+    }
+    MRBetaWindow_.second = GSArgs.find("MRBWin")->second;
+    MRBetaWindow_.first=strtod(MRBetaWindow_.second.c_str(), nullptr)*Globals::get()->GetClockInSeconds() *1.e9;
+
+    //Loads addback thresholds and Sub Event Windows (parsed in DetectorDriverXmlParser, with defaults)
+    // initializing  Addback Parameter maps
+    // map structure <subtype , <parameter , value > >
+    // Parameters are "thresh" , "subEvtWin", "refTime".
+    // ref times need to be in ns because the Gtime is in ns
+
+    double NgammaThreshold_ =  strtod(GSArgs.find("NaI_Thresh")->second.c_str(), nullptr);
+    double NsubEventWin_ =  strtod(GSArgs.find("NaI_SubWin")->second.c_str(), nullptr)/(Globals::get()->GetClockInSeconds());
+    double LHgammaThreshold_ =  strtod(GSArgs.find("LH_Thresh")->second.c_str(), nullptr);
+    double LHsubEventWin_ =  strtod(GSArgs.find("LH_SubWin")->second.c_str(), nullptr)/(Globals::get()->GetClockInSeconds());
+    double BHgammaThreshold_ =  strtod(GSArgs.find("BH_Thresh")->second.c_str(), nullptr);
+    double BHsubEventWin_ =  strtod(GSArgs.find("BH_SubWin")->second.c_str(), nullptr)/(Globals::get()->GetClockInSeconds());
+
+    std::map <std::string,double > paraData ;
+    paraData.insert(make_pair("thresh",NgammaThreshold_));
+    paraData.insert(make_pair("subEvtWin",NsubEventWin_));
+    paraData.insert(make_pair("refTime",-2.0*NsubEventWin_));
+    ParameterMap.emplace("nai",paraData);
+    paraData.clear();
+
+    paraData.insert(make_pair("thresh",LHgammaThreshold_));
+    paraData.insert(make_pair("subEvtWin",LHsubEventWin_));
+    paraData.insert(make_pair("refTime",-2.0*LHsubEventWin_));
+    ParameterMap.emplace("smallhag",paraData);
+    paraData.clear();
+
+    paraData.insert(make_pair("thresh",BHgammaThreshold_));
+    paraData.insert(make_pair("subEvtWin",BHsubEventWin_));
+    paraData.insert(make_pair("refTime",-2.0*BHsubEventWin_));
+    ParameterMap.emplace("bighag",paraData);
+    paraData.clear();
+
+    // initalize addback event structs
+    LHaddBack_ = new GSAddback(0.,0.,0.,0,0);
+    NaddBack_ = new GSAddback(0.,0.,0.,0,0);
+    BHaddBack_ = new GSAddback(0.,0.,0.,0,0);
+    FAILEDaddback_ = new GSAddback(numeric_limits<double>::max(),numeric_limits<double>::max(),
+                                   numeric_limits<double>::max(),numeric_limits<unsigned>::max(),
+                                   numeric_limits<unsigned long>::max());
+
+
+}
+
+bool GammaScintProcessor::PreProcess(RawEvent &event) {
+    if (!EventProcessor::PreProcess(event))
+        return (false);
+
+    /** From the Detector Driver we get the Pixie Event number and the system-wide first event time
+     * We get the event list for the "gscint" type.
+     */
+    firstGSEvent_ = false;
+    if (evtNum_ == 0){
+        firstEventTime_ = DetectorDriver::get()->GetFirstEventTime() * Globals::get()->GetClockInSeconds()*1.e9;
+        bunchLast_ = firstEventTime_;
+        firstGSEvent_= true;
+    }
+    evtNum_ = DetectorDriver::get()->GetEventNumber();
+    GSEvents_ = event.GetSummary("gscint")->GetList();
+
+    return (true);
+}
+
+
+bool GammaScintProcessor::Process(RawEvent &event) {
+    if (!EventProcessor::Process(event))
+        return (false);
+
+    if (SysRoot_) {
+        PEsing.clear(); // Clearing root output vector
+    }
+    hasLowResBeta_ = false;
+    hasMedResBeta_ = false;
+
+
+    if (!event.GetSummary("beta")->GetList().empty()) { //get pixie event level beta for setups with a "beta" type
+        hasLowResBeta_ = TreeCorrelator::get()->place("Beta")->status();
+        /**@todo Get beta list for beta:single (leribbs style) setups, but since we don't run much like this anymore its probably
+        * not super urgent */
+        if (!event.GetSummary("beta:double")->GetList().empty()) {
+            //also get the Low Res Bars for medium res beta gating.
+            lrtBetas = ((DoubleBetaProcessor *) DetectorDriver::get()->GetProcessor("DoubleBetaProcessor"))->GetLowResBars();
+            //Loop
+            BetaList.clear();
+            for (auto bIt = lrtBetas.begin(); bIt != lrtBetas.end(); bIt++) {
+                double betaTime = bIt->second.first;
+                double betaEn = bIt->second.second;
+                BetaList.emplace_back(make_pair(betaTime, betaEn));
+            }
+        }
+    } else {
+        ///@todo Get fragmentation style (pspsmt) "beta" for medium resolution beta gating
+    }
+
+
+    /** Which kind of bunching to use depends on the Facility. ISOL has access to the Tape Cycle and Time;
+    * while Fragmentation only has the time bunching (which is why it is the default FacilityType)
+    */
+    if (ISOL_) {
+        if (TreeCorrelator::get()->place("Cycle")->status()) {
+            double currentTime_ = TreeCorrelator::get()->place("Cycle")->last().time;
+            currentTime_ *= Globals::get()->GetClockInSeconds() * 1.e9;
+            if (currentTime_ != bunchLast_) {
+                double tdiff = (currentTime_ - bunchLast_) / 1.e6;
+                if (bunchNum_ == 0) {
+                    cout
+                            << " #  There are some events at the beginning of the first segment missing from Histograms that use cycleNum."
+                            << endl << " #  This is a product of not starting the cycle After the LDF." << endl
+                            << " #  This First TDIFF is most likely nonsense" << endl;
+                }
+                bunchLast_ = currentTime_;
+                bunchNum_++;
+                cout << endl << "Cycle Change " << endl << "Tdiff (Cycle start and Now) (ms)= " << tdiff << endl
+                     << "Starting on Cycle #" << bunchNum_ << endl;
+            }
+        }
+    } else {
+        double currentTime_ = GSEvents_.back()->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1.e9;
+        double tdiff = (currentTime_ - bunchLast_);
+        //cout <<"bunchLast_ = "<<bunchLast_<<endl<<"Tdiff from First to current = " << currentTime_ - firstEventTime_<<endl;
+        if (firstGSEvent_)
+            cout << "First Bunch. Current Bunch Size is " << bunchingTime_ << " seconds." << endl;
+
+        if (tdiff > (bunchingTime_ * 1.e9)) { //not working right now
+            bunchLast_ = currentTime_;
+            bunchNum_++;
+            cout << endl << "Bunch Change" << endl << "Now Starting Bunch # " << bunchNum_ << "." << endl;
+        };
+
+    }
+
+    //Plotting Multiplicities (BetaGated might be useful for Hagrids (LaBr) due to the internal activity
+    //also adding the multiplicities to root
+    for (auto subTypeList_ = typeList_.begin(); subTypeList_ != typeList_.end(); subTypeList_++) {
+        string TYPE = "gscint:";
+        const vector<ChanEvent *> &subEvent = event.GetSummary(TYPE + (*subTypeList_))->GetList();
+        unsigned int offset = ReturnOffset((*subTypeList_));
+        plot(DD_MULTI + offset, subEvent.size(), 0);
+        if (hasLowResBeta_)
+            plot(DD_MULTI + offset, subEvent.size(), 1);
+    } // end SubtypeList for loop
+
+    //start actual event loop
+    for (auto it = GSEvents_.begin(); it != GSEvents_.end(); it++) {
+        hasMedResBeta_=false;
+        string subType = (*it)->GetChanID().GetSubtype();
+        unsigned int subTypeOffset = ReturnOffset(subType);
+        double Genergy = (*it)->GetCalibratedEnergy();
+        double Gtime = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1.e9;
+        double decayTime = (Gtime - bunchLast_) / 1.0e9;
+
+        if (hasLowResBeta_) {
+            //loop the the "beta" events to find the current gamma event's closest beta event
+            //For the ORNL2016 data the beta multiplicy is mostly 1 so this is here for completeness and
+            //the possiblity of a future need.
+            for (auto it = BetaList.begin(); it != BetaList.end(); it++) {
+                double BetaTime =(*it).first * Globals::get()->GetClockInSeconds() * 1.e9;
+                double MRBtDiff =  BetaTime - Gtime;
+                if (MRBtDiff < 0)
+                    continue;
+                else if (MRBtDiff >= 0)   {
+                    hasMedResBeta_ = true;
+                    if (SysRoot_) {
+                        Gsing.BetaEnergy = (*it).second;
+                        Gsing.BetaGammaTDiff = MRBtDiff;
+                        Gsing.BetaTime = BetaTime;
+                    }
+                    break;
+                }
+            }// end BetaList Loop
+        }//end if medium resolution beta gating loop.
+
+        //DAMM PLOTS
+        plot(D_ENERGY + subTypeOffset, Genergy);
+        plot(DD_LONGTIME_ENERGY + subTypeOffset, Genergy, bunchNum_);
+        plot(DD_TIME_ENERGY + subTypeOffset, Genergy, decayTime / timeScales_.front());
+        if (hasLowResBeta_) {
+            plot(D_BGENERGY + subTypeOffset, Genergy);
+            timePloty(DD_BGTIME_ENERGY + subTypeOffset, Genergy, decayTime, timeScales_);
+            if (hasMedResBeta_)
+                plot(D_MBGENERGY + subTypeOffset, Genergy);
+        }
+
+
+        if (SysRoot_){
+            std::string Group;
+            if (!(*it)->GetChanID().GetTags().empty()) {
+                //Group and NumGroup NEED protection from empty sets/strings, but this should be taken care of by the above IF()
+                Group = (*it)->GetChanID().GetTags().begin()->c_str();; //only adds the first Tag as the grouping. @TODO to be fixed for any order or # of tags
+                Gsing.NumGroup = Group.back(); //gets last character of the group string for the number
+            }else {
+               Group = "N/A";
+                Gsing.NumGroup = -1; //store -1 for the group num if it isnt set
+           }
+            //root has issues with the strings in the PEsing Vector -> NumGroup (above )and NumType (here)
+            //NumGroup WILL repeat Numbers for the types (i.e. both nai and smallhag will have NumGroup =1 for some dets)
+            //so a root cut on the NumType will be REQUIRED
+            if (subType == "nai")
+                Gsing.NumType = 0;
+            else if (subType == "bighag")
+                Gsing.NumType = 1;
+            else if (subType == "smallhag")
+                Gsing.NumType = 2;
+            else
+                Gsing.NumType = -1;
+
+            Gsing.HasTrigBeta = hasTrigBeta_;
+            Gsing.Group = Group;
+            Gsing.LastBunchTime = bunchLast_;
+            Gsing.Energy = Genergy;
+            Gsing.RawEnergy = (*it)->GetEnergy();
+            Gsing.Type = subType;
+            Gsing.Time = Gtime;
+            Gsing.HasLowResBeta = hasLowResBeta_;
+            Gsing.BetaMulti = BetaList.size();
+            Gsing.EvtNum = evtNum_;
+            Gsing.BunchNum = bunchNum_;
+            Gsing.LastBunchTime = bunchLast_;
+            Gsing.DetNum = (*it)->GetChanID().GetLocation();
+            PEsing.emplace_back(Gsing);
+            Gsing=DefaultStruct; //reset structure
+            //Dont fill because we want 1 pixie event per tree entry, so we add the current structure in the last spot
+            //on a vector<> and then reset the structure. and we will at the end or Process()
+        } //end sysroot_
+
+       //Starting Rough (TypeWide) Addback
+    // (TYPEWIDE ADDBACK MUST BE THE LAST THING IN THE FOR LOOP due to the energy check below)
+
+    if (Genergy < (GetAddbackPara(subType, "thresh"))) { ;
+        continue;
+    }
+    //double abTdiff = abs(Gtime - (GetAddbackPara(subType, "refTime")));
+    double abTdiff = abs((*it)->GetTimeSansCfd()-GetAddbackPara(subType,"refTime"));
+
+    if (abTdiff > (GetAddbackPara(subType, "subEvtWin")) || evtNum_ != GetAddbackStruct(subType)->abevtnum) {
+        //if we are outside of the sub event window for a given subtype OR we have crossed a pixie evt boundary
+        // then fill the tree then zero the correct struc.
+
+        plot(D_ENERGY + subTypeOffset + ADDBACKOFFSET, GetAddbackStruct(subType)->energy);
+        if (hasLowResBeta_) {
+            plot(D_BGENERGY + subTypeOffset + ADDBACKOFFSET, GetAddbackStruct(subType)->energy);
+        }
+        //reset the correct addback struct to 0s
+        (*GetAddbackStruct(subType)) = GSAddback(0.,0.,0.,0,0);
+
+
+    }
+    if (GetAddbackStruct(subType)->multiplicity == 0) {
+        //only count as "beta gated" if the first addback event has a beta. (a catch incase the addback event
+            //crosses pixie events, which it shouldn't because process is closed at an event boundary )
+        GetAddbackStruct(subType)->ftime = (*it)->GetTimeSansCfd();
+    }
+        //Gets last entry in the addback vector for the correct subtype, and increments it with the current values
+        GetAddbackStruct(subType)->energy += (*it)->GetCalibratedEnergy();
+        GetAddbackStruct(subType)->time = (*it)->GetTimeSansCfd();
+        GetAddbackStruct(subType)->multiplicity += 1;
+        GetAddbackStruct(subType)->abevtnum = evtNum_;
+
+        SetAddbackRefTime(subType, (*it)->GetTimeSansCfd());
+    } //End GSEvents for loop
+
+    //now that we have processed every det event in the Pixie Event list. We wait for the DD to ask for the vector
+    //the vector is cleared at the beginning of Process() so we dont need to do it here.
+
+    EndProcess();
+    return (true);
+}
+
+
+unsigned int GammaScintProcessor::ReturnOffset(const std::string &subtype) {
+    if (subtype == "nai")
+        return (NaIOFFSET);
+    if (subtype == "bighag")
+        return (BIGHAG_OFFSET);
+    if (subtype == "smallhag")
+        return (LITTLEHAG_OFFSET);
+
+    return (numeric_limits<unsigned int>::max());
+}
+
+void GammaScintProcessor::SetAddbackRefTime(const std::string &subtype, const double &newRefTime) {
+    auto ito = ParameterMap.find(subtype);
+    if (ito == ParameterMap.end()) {
+        stringstream ss;
+        ss<<"Error in looking up Addback Parameters for "<<subtype <<" (Unknown Type)";
+        throw GeneralException(ss.str());
+    }else{
+        auto iti = ito->second.find("refTime");
+        if (iti == ParameterMap.find(subtype)->second.end()) {
+            stringstream ss;
+            ss << "Error in looking up Addback Reference Time for " << subtype << " (Unknown Parameter)";
+            throw GeneralException(ss.str());
+        }
+        iti->second = newRefTime;
+    }
+}
+
+double GammaScintProcessor::GetAddbackPara(const std::string &subtype, const std::string &option) {
+    auto ito = ParameterMap.find(subtype);
+    if (ito == ParameterMap.end()) {
+        stringstream ss;
+        ss<<"Error in looking up Addback Parameters for "<<subtype <<" (Unknown Type)";
+        throw GeneralException(ss.str());
+    }else {
+        auto iti = ito->second.find(option);
+        if (iti == ito->second.end()) {
+            stringstream ss;
+            ss << "Error in looking up Addback Parameter for " << subtype << " (Unknown Parameter)";
+            throw GeneralException(ss.str());
+        }
+        return iti->second;
+    }
+}
+
+GSAddback* GammaScintProcessor::GetAddbackStruct(const std::string &subtype) {
+    if (subtype == "nai")
+        return (NaddBack_);
+    else if (subtype == "bighag")
+        return (BHaddBack_);
+    else if (subtype == "smallhag")
+        return (LHaddBack_);
+    else
+        return (FAILEDaddback_);
+}
+
+/**
+ * Plot to multiple in "cycle" spectrums with different time scales (based on the size() of the timescale vector)
+ * (like grow and decay curves)
+ */
+void GammaScintProcessor::timePloty(int dammId, double x, double y,
+                                    const vector<float> &timeScale) {
+    for (unsigned int i = 0; i < timeScale.size(); i++) {
+        plot(dammId + i, x, y / timeScale[i]);
+    }
+}
+
+void GammaScintProcessor::DeclareHistogramTimeY(int dammId, int xsize, int ysize,const char *title, int halfWordsPerChan,
+                                            const vector<float > &timeScale, const char *units) {
+    stringstream fullTitle;
+    for (unsigned int i = 0; i < timeScale.size(); i++) {
+        fullTitle << title << " (" << timeScale[i] << " " << units << "/bin)";
+        histo.DeclareHistogram2D(dammId + i, xsize, ysize, fullTitle.str().c_str(),halfWordsPerChan, 1, 1);
+        fullTitle.str("");
+    }
+}
+void GammaScintProcessor::DeclareHistogramTimeY(int dammId, int xsize, int ysize, const char *title, int halfWordsPerChan,
+                                                const float  &timeScale, const char *units) {
+    stringstream fullTitle;
+    fullTitle << title << " (" << timeScale << " " << units << "/bin)";
+    histo.DeclareHistogram2D(dammId, xsize, ysize, fullTitle.str().c_str(), halfWordsPerChan, 1, 1);
+    fullTitle.str("");
+}
+
+
+

--- a/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
@@ -25,7 +25,7 @@ namespace dammIds {
     namespace gscint{
         const int LITTLEHAG_OFFSET = 0; //!< offset for 2" hagrid
         const int BIGHAG_OFFSET = 20; //!< offset for 3" hagrid
-        const int NaIOFFSET = 30; //!< offset for the Nai:beasts
+        const int NaIOFFSET = 40; //!< offset for the Nai:beasts
         const int ADDBACKOFFSET = 100; //!< offset for addback Spectra
         const int GAMMAGAMMAOFFSET = 150;//!< offset for the beta-gamma->gamma plots
 

--- a/Analysis/Utkscan/processors/source/LogicProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/LogicProcessor.cpp
@@ -65,6 +65,7 @@ LogicProcessor::LogicProcessor(void) : EventProcessor(dammIds::logic::OFFSET, da
     associatedTypes.insert("logic");
     associatedTypes.insert("timeclass"); // old detector type
     associatedTypes.insert("mtc");
+    cycleNum =0 ;
 }
 
 LogicProcessor::LogicProcessor(int offset, int range, bool doubleStop/*=false*/, bool doubleStart/*=false*/) :
@@ -205,10 +206,11 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
             }
             TreeCorrelator::get()->place("Beam")->activate(time);
             TreeCorrelator::get()->place("Cycle")->activate(time);
+            cycleNum++;
 
             LogStruc.beamStatus = true;
             LogStruc.tapeCycleStatus = true;
-            LogStruc.cycleNum = LogStruc.cycleNum++;
+            LogStruc.cycleNum = cycleNum;
             cout<<"Logic CycleNum = "<<LogStruc.cycleNum<<endl;
             LogStruc.lastTapeCycleStartTime= time * Globals::get()->GetClockInSeconds() * 1.0e9;
             LogStruc.lastBeamOnTime= time * Globals::get()->GetClockInSeconds() * 1.0e9;

--- a/Analysis/Utkscan/processors/source/LogicProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/LogicProcessor.cpp
@@ -65,7 +65,6 @@ LogicProcessor::LogicProcessor(void) : EventProcessor(dammIds::logic::OFFSET, da
     associatedTypes.insert("logic");
     associatedTypes.insert("timeclass"); // old detector type
     associatedTypes.insert("mtc");
-    cycleNum =0 ;
 }
 
 LogicProcessor::LogicProcessor(int offset, int range, bool doubleStop/*=false*/, bool doubleStart/*=false*/) :
@@ -178,10 +177,6 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
             double dt_start = time - TreeCorrelator::get()->place(place)->secondlast().time;
             TreeCorrelator::get()->place("TapeMove")->activate(time);
             TreeCorrelator::get()->place("Cycle")->deactivate(time);
-            LogStruc.tapeCycleStatus = false;
-            LogStruc.lastTapeMoveStartTime = time * Globals::get()->GetClockInSeconds() * 1.0e9;
-            LogStruc.tapeMoving = true;
-
             plot(D_TDIFF_MOVE_START, dt_start / mtcPlotResolution);
             plot(D_COUNTER, MOVE_START_BIN);
             plot(DD_TIME_DET_MTCEVENTS, time_x, MTC_START);
@@ -189,8 +184,6 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
             double dt_stop = time - TreeCorrelator::get()->place(place)->secondlast().time;
             double dt_move = time - TreeCorrelator::get()->place("logic_mtc_start_0")->last().time;
             TreeCorrelator::get()->place("TapeMove")->deactivate(time);
-            LogStruc.tapeMoving = false;
-
             plot(D_TDIFF_MOVE_STOP, dt_stop / mtcPlotResolution);
             plot(D_MOVETIME, dt_move / mtcPlotResolution);
             plot(D_COUNTER, MOVE_STOP_BIN);
@@ -206,15 +199,6 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
             }
             TreeCorrelator::get()->place("Beam")->activate(time);
             TreeCorrelator::get()->place("Cycle")->activate(time);
-            cycleNum++;
-
-            LogStruc.beamStatus = true;
-            LogStruc.tapeCycleStatus = true;
-            LogStruc.cycleNum = cycleNum;
-            cout<<"Logic CycleNum = "<<LogStruc.cycleNum<<endl;
-            LogStruc.lastTapeCycleStartTime= time * Globals::get()->GetClockInSeconds() * 1.0e9;
-            LogStruc.lastBeamOnTime= time * Globals::get()->GetClockInSeconds() * 1.0e9;
-
             plot(D_TDIFF_BEAM_START, dt_start / mtcPlotResolution);
             plot(D_COUNTER, BEAM_START_BIN);
             plot(DD_TIME_DET_MTCEVENTS, time_x, BEAM_START);
@@ -228,9 +212,6 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
                     continue;
             }
             TreeCorrelator::get()->place("Beam")->deactivate(time);
-            LogStruc.beamStatus = false;
-            LogStruc.lastBeamOffTime = time * Globals::get()->GetClockInSeconds() * 1.0e9;
-
             plot(D_TDIFF_BEAM_STOP, dt_stop / mtcPlotResolution);
             plot(D_BEAMTIME, dt_beam / mtcPlotResolution);
             plot(D_COUNTER, BEAM_STOP_BIN);
@@ -239,12 +220,9 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
             double dt_t1 = time - TreeCorrelator::get()->place("logic_t1_0")->last().time;
             plot(D_TDIFF_T1, dt_t1 / mtcPlotResolution);
             TreeCorrelator::get()->place("Protons")->activate(time);
-            LogStruc.lastProtonPulseTime =  time *Globals::get()->GetClockInSeconds() * 1.0e9;
-
         } else if (place == "logic_supercycle_0") {
             double dt_supercycle = time - TreeCorrelator::get()->place("logic_supercycle_0")->last().time;
             TreeCorrelator::get()->place("Supercycle")->activate(time);
-            LogStruc.lastSuperCycleTime = time * Globals::get()->GetClockInSeconds() * 1.0e9;
             plot(D_TDIFF_SUPERCYCLE, dt_supercycle / mtcPlotResolution);
         } else if (place == "logic_beam_0") {
             double last_time =
@@ -280,7 +258,7 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
         }
 
     }//events loop
-    pixie_tree_event_->logic_vec_.emplace_back(LogStruc);
+
     return (true);
 }
 

--- a/Analysis/Utkscan/processors/source/LogicProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/LogicProcessor.cpp
@@ -177,6 +177,9 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
             double dt_start = time - TreeCorrelator::get()->place(place)->secondlast().time;
             TreeCorrelator::get()->place("TapeMove")->activate(time);
             TreeCorrelator::get()->place("Cycle")->deactivate(time);
+            LogStruc.tapeCycleStatus = false;
+            LogStruc.lastTapeMoveStartTime = time * Globals::get()->GetClockInSeconds() * 1.0e9;
+            LogStruc.tapeMoving = true;
 
             plot(D_TDIFF_MOVE_START, dt_start / mtcPlotResolution);
             plot(D_COUNTER, MOVE_START_BIN);
@@ -185,6 +188,7 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
             double dt_stop = time - TreeCorrelator::get()->place(place)->secondlast().time;
             double dt_move = time - TreeCorrelator::get()->place("logic_mtc_start_0")->last().time;
             TreeCorrelator::get()->place("TapeMove")->deactivate(time);
+            LogStruc.tapeMoving = false;
 
             plot(D_TDIFF_MOVE_STOP, dt_stop / mtcPlotResolution);
             plot(D_MOVETIME, dt_move / mtcPlotResolution);
@@ -202,6 +206,13 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
             TreeCorrelator::get()->place("Beam")->activate(time);
             TreeCorrelator::get()->place("Cycle")->activate(time);
 
+            LogStruc.beamStatus = true;
+            LogStruc.tapeCycleStatus = true;
+            LogStruc.cycleNum = LogStruc.cycleNum++;
+            cout<<"Logic CycleNum = "<<LogStruc.cycleNum<<endl;
+            LogStruc.lastTapeCycleStartTime= time * Globals::get()->GetClockInSeconds() * 1.0e9;
+            LogStruc.lastBeamOnTime= time * Globals::get()->GetClockInSeconds() * 1.0e9;
+
             plot(D_TDIFF_BEAM_START, dt_start / mtcPlotResolution);
             plot(D_COUNTER, BEAM_START_BIN);
             plot(DD_TIME_DET_MTCEVENTS, time_x, BEAM_START);
@@ -215,18 +226,23 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
                     continue;
             }
             TreeCorrelator::get()->place("Beam")->deactivate(time);
+            LogStruc.beamStatus = false;
+            LogStruc.lastBeamOffTime = time * Globals::get()->GetClockInSeconds() * 1.0e9;
 
             plot(D_TDIFF_BEAM_STOP, dt_stop / mtcPlotResolution);
             plot(D_BEAMTIME, dt_beam / mtcPlotResolution);
             plot(D_COUNTER, BEAM_STOP_BIN);
             plot(DD_TIME_DET_MTCEVENTS, time_x, BEAM_STOP);
         } else if (place == "logic_t1_0") {
-            //TreeCorrelator::get()->place("Protons")->activate(time);
             double dt_t1 = time - TreeCorrelator::get()->place("logic_t1_0")->last().time;
             plot(D_TDIFF_T1, dt_t1 / mtcPlotResolution);
+            TreeCorrelator::get()->place("Protons")->activate(time);
+            LogStruc.lastProtonPulseTime =  time *Globals::get()->GetClockInSeconds() * 1.0e9;
+
         } else if (place == "logic_supercycle_0") {
-            TreeCorrelator::get()->place("Supercycle")->activate(time);
             double dt_supercycle = time - TreeCorrelator::get()->place("logic_supercycle_0")->last().time;
+            TreeCorrelator::get()->place("Supercycle")->activate(time);
+            LogStruc.lastSuperCycleTime = time * Globals::get()->GetClockInSeconds() * 1.0e9;
             plot(D_TDIFF_SUPERCYCLE, dt_supercycle / mtcPlotResolution);
         } else if (place == "logic_beam_0") {
             double last_time =
@@ -260,7 +276,9 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
         } else if (place == "logic_none_0") {
             plot(D_COUNTER_BEAM, BEAM_NONE);
         }
+
     }//events loop
+    pixie_tree_event_->logic_vec_.emplace_back(LogStruc);
     return (true);
 }
 

--- a/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
@@ -13,6 +13,7 @@
 #include <limits.h>
 
 #include "DammPlotIds.hpp"
+#include "DetectorDriver.hpp"
 #include "PspmtProcessor.hpp"
 #include "Globals.hpp"
 #include "Messenger.hpp"
@@ -57,6 +58,11 @@ bool PspmtProcessor::PreProcess(RawEvent &event){
 
     if (!EventProcessor::PreProcess(event))
         return false;
+
+    if (DetectorDriver::get()->GetSysRootOutput()) {
+        PSvec.clear();
+        PSstruct = DefaultStruc;
+    }
 
     //read in anode & dynode signals
     static const vector<ChanEvent *> &hiDynode = event.GetSummary("pspmt:dynode_high")->GetList();
@@ -127,32 +133,36 @@ bool PspmtProcessor::PreProcess(RawEvent &event){
              position_high.second * positionScale_ + positionOffset_);
     }
 
-    PSstruct.xa_l = xa_l ;
-    PSstruct.xb_l = xb_l ;
-    PSstruct.ya_l = ya_l ;
-    PSstruct.yb_l = yb_l ;
-    PSstruct.xa_h = xa_h ;
-    PSstruct.xb_h = xb_h ;
-    PSstruct.ya_h = ya_h ;
-    PSstruct.yb_h = yb_h ;
-    if (!lowDynode.empty()){
-    PSstruct.dy_l = lowDynode.front()->GetCalibratedEnergy();
-    PSstruct.dyL_time = lowDynode.front()->GetTimeSansCfd();
-    }
-    if (!hiDynode.empty()){
-    PSstruct.dy_h = hiDynode.front()->GetCalibratedEnergy();
-    PSstruct.dyH_time = hiDynode.front()->GetTimeSansCfd();
-    }
-    PSstruct.anodeLmulti = lowAnode.size();
-    PSstruct.anodeHmulti = hiAnode.size();
-    PSstruct.dyLmulti = lowDynode.size();
-    PSstruct.dyHmulti = hiDynode.size();
-    PSstruct.xposL = position_low.first;
-    PSstruct.yposL = position_low.second;
-    PSstruct.xposH = position_high.first;
-    PSstruct.yposH = position_high.second;
+    if (DetectorDriver::get()->GetSysRootOutput()) {
 
+        PSstruct.xa_l = xa_l;
+        PSstruct.xb_l = xb_l;
+        PSstruct.ya_l = ya_l;
+        PSstruct.yb_l = yb_l;
+        PSstruct.xa_h = xa_h;
+        PSstruct.xb_h = xb_h;
+        PSstruct.ya_h = ya_h;
+        PSstruct.yb_h = yb_h;
+        if (!lowDynode.empty()) {
+            PSstruct.dy_l = lowDynode.front()->GetCalibratedEnergy();
+            PSstruct.dyL_time = lowDynode.front()->GetTimeSansCfd();
+        }
+        if (!hiDynode.empty()) {
+            PSstruct.dy_h = hiDynode.front()->GetCalibratedEnergy();
+            PSstruct.dyH_time = hiDynode.front()->GetTimeSansCfd();
+        }
+        PSstruct.anodeLmulti = lowAnode.size();
+        PSstruct.anodeHmulti = hiAnode.size();
+        PSstruct.dyLmulti = lowDynode.size();
+        PSstruct.dyHmulti = hiDynode.size();
+        PSstruct.xposL = position_low.first;
+        PSstruct.yposL = position_low.second;
+        PSstruct.xposH = position_high.first;
+        PSstruct.yposH = position_high.second;
 
+        PSvec.emplace_back(PSstruct);
+        PSstruct=DefaultStruc;
+    }
     EndProcess();
     return (true);
 

--- a/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
@@ -60,8 +60,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event){
         return false;
 
     if (DetectorDriver::get()->GetSysRootOutput()) {
-        PSvec.clear();
-        PSstruct = DefaultStruc;
+        PSstruct = processor_struct::PSPMT_DEFAULT_STRUCT;
     }
 
     //read in anode & dynode signals
@@ -160,8 +159,8 @@ bool PspmtProcessor::PreProcess(RawEvent &event){
         PSstruct.xposH = position_high.first;
         PSstruct.yposH = position_high.second;
 
-        PSvec.emplace_back(PSstruct);
-        PSstruct=DefaultStruc;
+        pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
+        PSstruct = processor_struct::PSPMT_DEFAULT_STRUCT;
     }
     EndProcess();
     return (true);

--- a/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
@@ -1,6 +1,6 @@
 ///@file PspmtProcessor.cpp
-///@Processes information from a Position Sensitive PMT.  No Pixel work yet.
-///@author A. Keeler
+///@Processes information from a Position Sensitive PMT.  No Pixel work yet. 
+///@author A. Keeler, S. Go, S. V. Paulauskas 
 ///@date July 8, 2018
 
 #include <algorithm>

--- a/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
@@ -61,8 +61,10 @@ void PspmtProcessor::DeclarePlots(void) {
     DeclareHistogram2D(DD_DESI_GATED_ION, SB, SB, "Ion-scint positions - silicon dE-gated");
 }
 
-PspmtProcessor::PspmtProcessor(const std::string &vd, const double &scale, const unsigned int &offset,
-                               const double &threshold) :EventProcessor(OFFSET, RANGE, "PspmtProcessor"){
+PspmtProcessor::PspmtProcessor(const std::string &vd, const double &yso_scale, const unsigned int &yso_offset,
+			       const double &yso_threshold, const double &front_scale,
+			       const unsigned int &front_offset, const double &front_threshold)
+				:EventProcessor(OFFSET, RANGE, "PspmtProcessor"){
 
 
     if(vd == "SIB064_1018" || vd == "SIB064_1730")
@@ -73,10 +75,13 @@ PspmtProcessor::PspmtProcessor(const std::string &vd, const double &scale, const
         vdtype_ = UNKNOWN;
 
     VDtypeStr = vd;
-    positionScale_ = scale;
-    positionOffset_ = offset;
-    threshold_ = threshold;
-    ThreshStr = threshold;
+    positionScale_ = yso_scale;
+    positionOffset_ = yso_offset;
+    threshold_ = yso_threshold;
+    front_positionScale_ = front_scale;
+    front_positionOffset_ = front_offset;
+    front_threshold_ = front_threshold;
+    ThreshStr = yso_threshold;
     associatedTypes.insert("pspmt");
 }
 
@@ -221,8 +226,8 @@ bool PspmtProcessor::PreProcess(RawEvent &event){
         hasPosition_ion = true;
         position_ion.first = (top_l + bottom_l - top_r - bottom_r) / (top_l + top_r + bottom_l + bottom_r);
         position_ion.second  = (top_l + top_r - bottom_l - bottom_r) / (top_l + top_r + bottom_l + bottom_r);
-        plot(DD_POS_ION, position_ion.first * positionScale_ + positionOffset_,
-             position_ion.second * positionScale_ + positionOffset_);
+        plot(DD_POS_ION, position_ion.first * front_positionScale_ + front_positionOffset_,
+             position_ion.second * front_positionScale_ + front_positionOffset_);
     }
 
 

--- a/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
@@ -26,7 +26,7 @@ namespace dammIds {
         const int DD_DYNODE_QDC = 0;
         const int DD_POS_LOW = 1;
         const int DD_POS_HIGH = 2;
-        const int DD_VETO_ENERGY = 3;
+        const int DD_PLASTIC_EN = 3;
     }
 }
 
@@ -34,7 +34,7 @@ void PspmtProcessor::DeclarePlots(void) {
     DeclareHistogram2D(DD_DYNODE_QDC, SD, S2, "Dynode QDC- Low gain 0, High gain 1");
     DeclareHistogram2D(DD_POS_LOW, SB, SB, "Low-gain Positions");
     DeclareHistogram2D(DD_POS_HIGH, SB, SB, "High-gain Positions");
-    DeclareHistogram2D(DD_VETO_ENERGY,SD,S3, "Plastic Energy, 0,1 = VETO, 3-6 = Ion Trigger");
+    DeclareHistogram2D(DD_PLASTIC_EN,SD,S4, "Plastic Energy, 0-3 = VETO, 5-8 = Ion Trigger");
 }
 
 PspmtProcessor::PspmtProcessor(const std::string &vd, const double &scale, const unsigned int &offset,
@@ -87,23 +87,23 @@ bool PspmtProcessor::PreProcess(RawEvent &event){
     for (auto it = veto.begin(); it != veto.end(); it++ ){
         int loc =  (*it)->GetChanID().GetLocation();
 
-        plot(DD_VETO_ENERGY,(*it)->GetEnergy(),loc);
+        plot(DD_PLASTIC_EN,(*it)->GetCalibratedEnergy(),loc);
 
         if (vetoEnergys.find(loc) != vetoEnergys.end()) {
-            vetoEnergys.find(loc)->second = (*it)->GetEnergy();
+            vetoEnergys.find(loc)->second = (*it)->GetCalibratedEnergy();
         }else {
-            vetoEnergys.emplace(loc,(*it)->GetEnergy());
+            vetoEnergys.emplace(loc,(*it)->GetCalibratedEnergy());
         }
 
     }
     for (auto it = ionTrig.begin(); it != ionTrig.end(); it++) {
         int loc =  (*it)->GetChanID().GetLocation();
-        plot(DD_VETO_ENERGY, (*it)->GetEnergy(), loc + numOfVetoChans + 1); //max veto chan +1 for readablility
+        plot(DD_PLASTIC_EN, (*it)->GetCalibratedEnergy(), loc + numOfVetoChans + 1); //max veto chan +1 for readablility
 
         if (IonTrigEnergies.find(loc) != IonTrigEnergies.end()) {
-            IonTrigEnergies.find(loc)->second = (*it)->GetEnergy();
+            IonTrigEnergies.find(loc)->second = (*it)->GetCalibratedEnergy();
         }else {
-            IonTrigEnergies.emplace(loc,(*it)->GetEnergy());
+            IonTrigEnergies.emplace(loc,(*it)->GetCalibratedEnergy());
         }
     }
     //set up position calculation for low and high gain signals

--- a/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
@@ -292,9 +292,9 @@ bool PspmtProcessor::PreProcess(RawEvent &event){
         }
     }
 
-    if(hasPosition_low){
-        for(auto de_it = desi.begin(); de_it != desi.end(); de_it++) {
-            plot(D_DESI_YSO_GATED,(*de_it)->GetCalibratedEnergy());
+    if(hasPosition_low) {
+        for (auto de_it = desi.begin(); de_it != desi.end(); de_it++) {
+            plot(D_DESI_YSO_GATED, (*de_it)->GetCalibratedEnergy());
         }
         for (auto it_sep = separatorScint.begin(); it_sep != separatorScint.end(); it_sep++) {
             if ((*it_sep)->GetChanID().HasTag("left")) {
@@ -302,6 +302,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event){
             } else if ((*it_sep)->GetChanID().HasTag("right")) {
                 plot(DD_SEPAR_YSO_GATED, (*it_sep)->GetCalibratedEnergy(), 1);
             }
+        }
     }
 
     if(hasUpstream)

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -140,7 +140,7 @@ bool VandleProcessor::Process(RawEvent &event) {
     TimingMapBuilder bldStarts(startEvents);
     starts_ = bldStarts.GetMap();
 
-
+/*
     static const std::vector<ChanEvent *> &chEvents = event.GetEventList();
     for( auto chEvent : chEvents ) {
         if( chEvent->GetChannelNumber() == 0 && chEvent->GetModuleNumber() == 0 ){
@@ -148,7 +148,7 @@ bool VandleProcessor::Process(RawEvent &event) {
             // printf("vandles.ExtTimeStamp %llu \n", vandles.ExtTimeStamp);
         }
     }
-
+*/
     static const vector<ChanEvent *> &doubleBetaStarts = event.GetSummary("beta:double:start")->GetList();
     BarBuilder startBars(doubleBetaStarts);
     startBars.BuildBars();

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -122,9 +122,6 @@ bool VandleProcessor::Process(RawEvent &event) {
     if (!EventProcessor::Process(event))
         return false;
 
-    if (DetectorDriver::get()->GetSysRootOutput()) {
-        VanVec.clear();
-    }
     plot(D_DEBUGGING, 30);
 
     geSummary_ = event.GetSummary("clover");
@@ -156,7 +153,6 @@ bool VandleProcessor::Process(RawEvent &event) {
     barStarts_ = startBars.GetBarMap();
 
     if (DetectorDriver::get()->GetSysRootOutput()){
-        VanVec.clear();
         vandles.vMulti = bars_.size();
     }
 
@@ -202,8 +198,8 @@ void VandleProcessor::AnalyzeBarStarts(const BarDetector &bar, unsigned int &bar
                 vandles.tof = tof;
                 vandles.corTof = corTof;
                 vandles.qdcPos = bar.GetQdcPosition();
-                VanVec.emplace_back(vandles);
-                vandles=DefaultStruct;
+                pixie_tree_event_->vandle_vec_.emplace_back(vandles);
+                vandles = processor_struct::VANDLES_DEFAULT_STRUCT;
             }
         }
 }
@@ -234,8 +230,8 @@ void VandleProcessor::AnalyzeStarts(const BarDetector &bar, unsigned int &barLoc
                 vandles.tof = tof;
                 vandles.corTof = corTof;
                 vandles.qdcPos = bar.GetQdcPosition();
-                VanVec.emplace_back(vandles);
-                vandles=DefaultStruct;
+                pixie_tree_event_->vandle_vec_.emplace_back(vandles);
+                vandles = processor_struct::VANDLES_DEFAULT_STRUCT;
             }
         }
 }

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -122,8 +122,9 @@ bool VandleProcessor::Process(RawEvent &event) {
     if (!EventProcessor::Process(event))
         return false;
 
-    VanVec.clear();
-
+    if (DetectorDriver::get()->GetSysRootOutput()) {
+        VanVec.clear();
+    }
     plot(D_DEBUGGING, 30);
 
     geSummary_ = event.GetSummary("clover");
@@ -154,6 +155,11 @@ bool VandleProcessor::Process(RawEvent &event) {
     startBars.BuildBars();
     barStarts_ = startBars.GetBarMap();
 
+    if (DetectorDriver::get()->GetSysRootOutput()){
+        VanVec.clear();
+        vandles.vMulti = bars_.size();
+    }
+
     for (BarMap::iterator it = bars_.begin(); it != bars_.end(); it++) {
         TimingDefs::TimingIdentifier barId = (*it).first;
         BarDetector bar = (*it).second;
@@ -166,9 +172,6 @@ bool VandleProcessor::Process(RawEvent &event) {
         else
             AnalyzeStarts(bar, barId.first);
 
-        vandles.vMulti = bars_.size();
-        VanVec.emplace_back(vandles);
-        vandles = DefaultStruct;
     }
 
     EndProcess();
@@ -188,15 +191,20 @@ void VandleProcessor::AnalyzeBarStarts(const BarDetector &bar, unsigned int &bar
             PlotTofHistograms(tof, corTof,NCtof, bar.GetQdc(), barLoc * numStarts_ + startLoc,
                               ReturnOffset(bar.GetType()),caled);
 
-            //Fill Root struct
-            vandles.sTime = start.GetTimeAverage();
-            vandles.qdc=bar.GetQdc();
-            vandles.barNum = barLoc;
-            vandles.barType = bar.GetType();
-            vandles.tdiff = bar.GetTimeDifference();
-            vandles.tof = tof;
-            vandles.corTof = corTof;
-            vandles.qdcPos = bar.GetQdcPosition();
+            if (DetectorDriver::get()->GetSysRootOutput()){
+                //Fill Root struct
+                vandles.sNum = startLoc;
+                vandles.sTime = start.GetTimeAverage();
+                vandles.qdc = bar.GetQdc();
+                vandles.barNum = barLoc;
+                vandles.barType = bar.GetType();
+                vandles.tdiff = bar.GetTimeDifference();
+                vandles.tof = tof;
+                vandles.corTof = corTof;
+                vandles.qdcPos = bar.GetQdcPosition();
+                VanVec.emplace_back(vandles);
+                vandles=DefaultStruct;
+            }
         }
 }
 
@@ -215,15 +223,20 @@ void VandleProcessor::AnalyzeStarts(const BarDetector &bar, unsigned int &barLoc
 
             PlotTofHistograms(tof, corTof, NCtof,bar.GetQdc(), barLoc * numStarts_ + startLoc,
                               ReturnOffset(bar.GetType()),caled);
-            //Fill Root struct
-            vandles.sTime = start.GetTimeSansCfd();
-            vandles.qdc=bar.GetQdc();
-            vandles.barNum = barLoc;
-            vandles.barType = bar.GetType();
-            vandles.tdiff = bar.GetTimeDifference();
-            vandles.tof = tof;
-            vandles.corTof = corTof;
-            vandles.qdcPos = bar.GetQdcPosition();
+            if (DetectorDriver::get()->GetSysRootOutput()){
+                //Fill Root struct
+                vandles.sNum=startLoc;
+                vandles.sTime = start.GetTimeSansCfd();
+                vandles.qdc = bar.GetQdc();
+                vandles.barNum = barLoc;
+                vandles.barType = bar.GetType();
+                vandles.tdiff = bar.GetTimeDifference();
+                vandles.tof = tof;
+                vandles.corTof = corTof;
+                vandles.qdcPos = bar.GetQdcPosition();
+                VanVec.emplace_back(vandles);
+                vandles=DefaultStruct;
+            }
         }
 }
 

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -140,6 +140,15 @@ bool VandleProcessor::Process(RawEvent &event) {
     TimingMapBuilder bldStarts(startEvents);
     starts_ = bldStarts.GetMap();
 
+
+    static const std::vector<ChanEvent *> &chEvents = event.GetEventList();
+    for( auto chEvent : chEvents ) {
+        if( chEvent->GetChannelNumber() == 0 && chEvent->GetModuleNumber() == 0 ){
+            vandles.ExtTimeStamp = chEvent->GetExternalTimeStamp();
+            // printf("vandles.ExtTimeStamp %llu \n", vandles.ExtTimeStamp);
+        }
+    }
+
     static const vector<ChanEvent *> &doubleBetaStarts = event.GetSummary("beta:double:start")->GetList();
     BarBuilder startBars(doubleBetaStarts);
     startBars.BuildBars();
@@ -257,7 +266,7 @@ void VandleProcessor::FillVandleOnlyHists(void) {
         unsigned int OFFSET = ReturnOffset(barId.second).first;
         unsigned int NOCALOFFSET = ReturnOffset(barId.second).second;
         double NoCalTDiff = (*it).second.GetLeftSide().GetHighResTimeInNs()-(*it).second.GetRightSide().GetHighResTimeInNs();
-        
+
         plot(DD_MAXIMUMBARS + OFFSET,(*it).second.GetLeftSide().GetMaximumValue(), barId.first*2);
         plot(DD_MAXIMUMBARS + OFFSET,(*it).second.GetRightSide().GetMaximumValue(), barId.first*2+1);
 

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -135,7 +135,7 @@ bool VandleProcessor::Process(RawEvent &event) {
 
     static const vector<ChanEvent *> &betaStarts = event.GetSummary("beta_scint:beta")->GetList();
     static const vector<ChanEvent *> &liquidStarts = event.GetSummary("liquid:scint:start")->GetList();
-    static const vector<ChanEvent *> &pspmtStarts = event.GetSummary("pspmt:dynode_high")->GetList();
+    static const vector<ChanEvent *> &pspmtStarts = event.GetSummary("pspmt:dynode_high:start")->GetList();
 
     static const vector<ChanEvent *> &LIonVeto =  event.GetSummary("pspmt:veto")->GetList();
     static const vector<ChanEvent *> &IondE=  event.GetSummary("pspmt:ion")->GetList();

--- a/Cmake/modules/FindXIA.cmake
+++ b/Cmake/modules/FindXIA.cmake
@@ -14,8 +14,8 @@ unset(XIA_LIBRARY_DIR CACHE)
 #Find the library path by looking for the library.
 find_path(XIA_LIBRARY_DIR
         NAMES libPixie16App.a libPixie16Sys.a
-        HINTS ${XIA_ROOT_DIR}
-        PATHS /opt/xia/current /opt/xia/software
+        HINTS ${XIA_FIRMWARE_DIR}
+        PATHS /opt/xia/current /opt/xia/software /xia_api
         PATH_SUFFIXES software
         DOC "Path to pixie library.")
 
@@ -33,6 +33,7 @@ set(XIA_FIRMWARE_DIR ${XIA_FIRMWARE_DIR} CACHE PATH "Path to folder containing X
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(XIA DEFAULT_MSG XIA_LIBRARY_DIR)
 
+message(STATUS "XIA_LIBRARY_DIR=${XIA_LIBRARY_DIR}")
 if (XIA_FOUND)
     set(XIA_INCLUDE_DIR ${XIA_LIBRARY_DIR}/inc ${XIA_LIBRARY_DIR}/sys ${XIA_LIBRARY_DIR}/app)
     set(XIA_LIBRARIES -lPixie16App -lPixie16Sys)


### PR DESCRIPTION
This branch contains the new features from the RIKEN2018 (ribf-136) experiment.

Summery of the major changes:
1) External Timing Clock-> added the ability to decode the external time stamp which is read in from the front pins.
1.5) updated poll2 commands to show the Ext Timing stuff (csr_test etc)
2)Root output from the detector driver. The various processors create a vector of detector events which is filled After the Process() call, once per pixie event. This means that root's Draw() from the interpreter will only work inside of a processor vector (i.e.  "vandle qdc vs vandle tof" is ok but "vandle tof vs clover energy" is not) if you want to make cross vector plots you need a script (like a TSelector) and the TTreeReader 
3) fixed a bug in the `utkscanor` initialization  which required a dummy `-o `argument. This is no longer required. 
4) new CloverFragProcessor which removes the more complex clover plots (most of which required MTC). This new Processor overlaps with the CloverProcessor in the DammPlotID space. so you can only use 1 or the other. They also fill the same vector in the root output 

Some other updates to a few of the Detector Processor. As well as refinement of the root output. 

This also includes the changes from #300, so i will be closing that one

As for testing, this has been my daily driver base for a while now. I have used it with ORNL2016 and E14060, RIBF136 data.
