### PR TITLE
2019updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ install/
 *.layout
 *.save
 .idea/
+.vscode
 
 #DAMM files
 *.drr

--- a/Acquisition/Interface/include/PixieSupport.h
+++ b/Acquisition/Interface/include/PixieSupport.h
@@ -112,10 +112,10 @@ public:
 
     BitFlipper() {
         bit = 0;
-        num_toggle_bits = 22;
+        num_toggle_bits = 24;
     }
 
-    BitFlipper(unsigned int bit_, unsigned int num_toggle_bits_ = 22) {
+    BitFlipper(unsigned int bit_, unsigned int num_toggle_bits_ = 24) {
         bit = bit_;
         num_toggle_bits = num_toggle_bits_;
     }

--- a/Acquisition/Interface/source/PixieSupport.cpp
+++ b/Acquisition/Interface/source/PixieSupport.cpp
@@ -64,15 +64,15 @@ const std::vector<std::string> BitFlipper::csr_txt({"Respond to group triggers o
 #else
 const std::vector<std::string> BitFlipper::toggle_names(
         {"", "", "good", "", "", "polarity", "", "", "trace", "QDC", "CFD",
-         "global", "raw", "trigger", "gain", "pileup", "catcher", "", "SHE","","","ExtTime"});
+         "globtrig", "raw", "chantrig", "gain", "pileup", "catcher", "", "SHE","","","ExtTime","ExtFastTrig","PeakSamp"});
 const std::vector<std::string> BitFlipper::csr_txt(
         {"", "", "Good Channel", "", "", "Trigger positive", "", "",
          "Enable trace capture", "Enable QDC sums capture",
          "Enable CFD trigger mode", "Enable global trigger validation",
          "Enable raw energy sums capture",
          "Enable channel trigger validation", "LO/HI gain",
-         "Pileup rejection control", "Hybrid bit", "",
-         "SHE single trace capture","","","External Timing"});
+         "Pileup Rejection", "Inverse Pileup ", "",
+         "SHE single trace capture (grouptrigsel)","","","Enable External Timestamping","Enable External Fast Trigger","Enable Override Peak Sample Point"});
 #endif
 
 void BitFlipper::Help() {
@@ -110,7 +110,7 @@ void BitFlipper::SetBit(std::string bit_) {
 }
 
 void BitFlipper::CSRAtest(unsigned int input_) {
-    Test(22, input_, csr_txt);
+    Test(24, input_, csr_txt);
 }
 
 bool BitFlipper::Test(unsigned int num_bits_, unsigned int input_,
@@ -141,7 +141,7 @@ bool BitFlipper::Test(unsigned int num_bits_, unsigned int input_,
     std::cout << " Input: 0x" << std::hex << input_ << " (" << std::dec
               << input_ << ")\n";
     if (!text_.empty()) {
-        std::cout << "  Bit   On?	Value	   Total	Bit Function\n";
+        std::cout << "  Bit  On?  Value       Total	  Bit Function\n";
     } else { std::cout << "  Bit   On?	Value	   Total\n"; }
 
     std::string bit_function;
@@ -152,39 +152,39 @@ bool BitFlipper::Test(unsigned int num_bits_, unsigned int input_,
         if (active_bits[i]) {
             if (Display::hasColorTerm) {
                 if (i < 10) {
-                    std::cout << TermColors::DkGreen << "   0" << i << "	1  "
+                    std::cout << TermColors::DkGreen << "  0" << i << "	1   "
                               << PadStr(bit_values[i], 12);
-                    std::cout << PadStr(running_total[i], 12) << bit_function
+                    std::cout << PadStr(running_total[i], 10) << bit_function
                               << TermColors::Reset << std::endl;
                 } else {
-                    std::cout << TermColors::DkGreen << "   " << i << "	1  "
+                    std::cout << TermColors::DkGreen << "  " << i << "	1   "
                               << PadStr(bit_values[i], 12);
-                    std::cout << PadStr(running_total[i], 12) << bit_function
+                    std::cout << PadStr(running_total[i], 10) << bit_function
                               << TermColors::Reset << std::endl;
                 }
             } else {
                 if (i < 10) {
-                    std::cout << "   " << i << "	1  "
+                    std::cout << "  0" << i << "	1   "
                               << PadStr(bit_values[i], 12)
-                              << PadStr(running_total[i], 12) << bit_function
+                              << PadStr(running_total[i], 10) << bit_function
                               << std::endl;
                 } else {
-                    std::cout << "   " << i << "	1  "
+                    std::cout << "  " << i << "	1   "
                               << PadStr(bit_values[i], 12)
-                              << PadStr(running_total[i], 12) << bit_function
+                              << PadStr(running_total[i], 10) << bit_function
                               << std::endl;
                 }
             }
         } else {
             if (i < 10) {
-                std::cout << "   0" << i << "	0  "
+                std::cout << "  0" << i << "	0   "
                           << PadStr(bit_values[i], 12);
-                std::cout << PadStr(running_total[i], 12) << bit_function
+                std::cout << PadStr(running_total[i], 10) << bit_function
                           << std::endl;
             } else {
-                std::cout << "   " << i << "	0  "
+                std::cout << "  " << i << "	0   "
                           << PadStr(bit_values[i], 12);
-                std::cout << PadStr(running_total[i], 12) << bit_function
+                std::cout << PadStr(running_total[i], 10) << bit_function
                           << std::endl;
             }
         }

--- a/Acquisition/Poll/source/poll2_core.cpp
+++ b/Acquisition/Poll/source/poll2_core.cpp
@@ -78,7 +78,8 @@ bool IsNumeric(const std::string &input_, const std::string &prefix_/*=""*/, con
 
 std::vector<std::string> chan_params = {"TRIGGER_RISETIME", "TRIGGER_FLATTOP", "TRIGGER_THRESHOLD", "ENERGY_RISETIME", "ENERGY_FLATTOP", "TAU", "TRACE_LENGTH",
                                         "TRACE_DELAY", "VOFFSET", "XDT", "BASELINE_PERCENT", "EMIN", "BINFACTOR", "CHANNEL_CSRA", "CHANNEL_CSRB", "BLCUT",
-                                        "ExternDelayLen", "ExtTrigStretch", "ChanTrigStretch", "FtrigoutDelay", "FASTTRIGBACKLEN"};
+                                        "ExternDelayLen", "ExtTrigStretch", "ChanTrigStretch", "FtrigoutDelay", "FASTTRIGBACKLEN" , "VetoStretch", "CFDDelay" ,
+                                        "CFDScale", "CFDThresh", "QDCLen0", "QDCLen1", "QDCLen2", "QDCLen3", "QDCLen4", "QDCLen5", "QDCLen6", "QDCLen7" };
 
 std::vector<std::string> mod_params = {"MODULE_CSRA", "MODULE_CSRB", "MODULE_FORMAT", "MAX_EVENTS", "SYNCH_WAIT", "IN_SYNCH", "SLOW_FILTER_RANGE",
                                        "FAST_FILTER_RANGE", "MODULE_NUMBER", "TrigConfig0", "TrigConfig1", "TrigConfig2","TrigConfig3"};

--- a/Analysis/Resources/include/ChannelConfiguration.hpp
+++ b/Analysis/Resources/include/ChannelConfiguration.hpp
@@ -50,6 +50,9 @@ public:
     ///@return the pair of fitting parameters to use in fits.
     std::pair<double, double> GetFittingParameters() const { return fittingParameters_; }
 
+    ///return the frequency for this channel
+    int GetModFreq() const { return modFreq_ ; }
+
     ///@return The value of the private variable location
     unsigned int GetLocation() const { return location_; }
 
@@ -112,6 +115,10 @@ public:
     /// Sets the pair of parameters that are needed for fitting analysis
     ///@param[in] a : The pair of parameters to set
     void SetFittingParameters(const std::pair<double, double> &a) { fittingParameters_ = a; }
+
+    /// Sets the frequency of the module for this channel
+    ///@param[in] a : The frequency to set 
+    void SetModFreq(const int &a) { modFreq_ = a; }
 
     /// Sets the Group string. Mainly used for the "addback" in the PostPaassProcessor ROOT code
     ///@param[in] a : The Group string to set
@@ -192,6 +199,7 @@ private:
     unsigned int discriminationStartInSamples_; ///< The position from the max that we'll do particle discrimination
     TrapFilterParameters energyFilterParameters_; ///< Parameters to use for energy filter calculations
     std::pair<double, double> fittingParameters_; ///< The parameters to use for the fitting routines
+    int modFreq_; ///<Frequency of the module for this channel 
     unsigned int location_; ///< Specifies the real world location of the channel.
     std::string subtype_; ///< Specifies the detector sub type
     std::string group_; ///<Specifies the detector group

--- a/Analysis/ScanLibraries/source/XiaListModeDataMask.cpp
+++ b/Analysis/ScanLibraries/source/XiaListModeDataMask.cpp
@@ -37,8 +37,7 @@ FIRMWARE XiaListModeDataMask::ConvertStringToFirmware(const std::string &type) {
         firmware = R30980;
     else if (firmwareNumber >= 30981 && firmwareNumber < 34688)
         firmware = R30981;
-    else if (firmwareNumber ==
-             34688) //compare exactly here since nothing higher
+    else if (firmwareNumber == 34688) //compare exactly here since nothing higher
         firmware = R34688;
     else {
         msg << "XiaListModeDataMask::CovnertStringToFirmware : "
@@ -83,6 +82,8 @@ XiaListModeDataMask::GetCfdFractionalTimeMask() const {
             case R30474:
             case R30980:
             case R30981:
+                mask = 0x3FFF0000;
+                break;
             case R34688:
                 mask = 0x3FFF0000;
                 break;
@@ -156,6 +157,8 @@ XiaListModeDataMask::GetCfdForcedTriggerBitMask() const {
             case R30474:
             case R30980:
             case R30981:
+                mask = 0x80000000;
+                bit = 31;
             case R34688:
                 mask = 0x80000000;
                 bit = 31;
@@ -184,6 +187,8 @@ XiaListModeDataMask::GetCfdTriggerSourceMask() const {
             case R30474:
             case R30980:
             case R30981:
+                mask = 0x40000000;
+                bit = 30;
             case R34688:
                 mask = 0x40000000;
                 bit = 30;
@@ -337,6 +342,7 @@ double XiaListModeDataMask::GetCfdSize() const {
                 break;
             case R30980:
             case R30981:
+                val = 16384;
             case R34688:
             case R30474:
                 val = 16384;

--- a/Analysis/Utilities/Scope/source/ScopeUnpacker.cpp
+++ b/Analysis/Utilities/Scope/source/ScopeUnpacker.cpp
@@ -93,7 +93,7 @@ void ScopeUnpacker::ResetGraph(const unsigned int &size) {
     graph->SetMarkerStyle(kFullDotSmall);
 
     if (size != x_vals.size()) {
-        cout << "ScopeUnpacker::ResetGraph : " << "Changing trace length from " << x_vals.size() << " to " << size << " ns.\n";
+        cout << "ScopeUnpacker::ResetGraph : " << "Changing trace length from " << x_vals.size() << " to " << size << " adc ticks.\n";
         x_vals.resize(size);
         for (size_t index = 0; index < x_vals.size(); index++)
             x_vals[index] = index;

--- a/Analysis/Utkscan/CMakeLists.txt
+++ b/Analysis/Utkscan/CMakeLists.txt
@@ -9,6 +9,11 @@ option(PAASS_UTKSCAN_ONLINE "Options for online scans" OFF)
 option(PAASS_UTKSCAN_TREE_DEBUG "Debugging info for TreeCorrelator" OFF)
 option(PAASS_UTKSCAN_VERBOSE "Make Scan More Verbose" OFF)
 
+mark_as_advanced(PAASS_UTKSCAN_GAMMA_GATES)
+mark_as_advanced(PAASS_UTKSCAN_ONLINE)
+mark_as_advanced(PAASS_UTKSCAN_TREE_DEBUG)
+mark_as_advanced(PAASS_UTKSCAN_VERBOSE)
+
 # newreadout is needed to account for a change to pixie16 readout
 # structure change on 03/20/08. Is is REQUIRED!!
 add_definitions(-D newreadout)

--- a/Analysis/Utkscan/analyzers/include/FittingAnalyzer.hpp
+++ b/Analysis/Utkscan/analyzers/include/FittingAnalyzer.hpp
@@ -10,6 +10,7 @@
 #ifndef __FITTINGANALYZER_HPP_
 #define __FITTINGANALYZER_HPP_
 
+#include "set"
 #include <string>
 
 #include "TimingDriver.hpp"
@@ -20,7 +21,7 @@
 class FittingAnalyzer : public TraceAnalyzer {
 public:
     ///Default Constructor
-    FittingAnalyzer(const std::string &s);
+    FittingAnalyzer(const std::string &s, const std::set<std::string> &tokens);
 
     /** Default Destructor */
     ~FittingAnalyzer();
@@ -34,6 +35,7 @@ public:
 
 private:
     TimingDriver *driver_;
+    std::set<std::string> ignoredTypes_;
 };
 
 #endif // __FITTINGANALYZER_HPP_

--- a/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
@@ -29,7 +29,7 @@
 
 using namespace std;
 
-FittingAnalyzer::FittingAnalyzer(const std::string &s) {
+FittingAnalyzer::FittingAnalyzer(const std::string &s ,const std::set<std::string> &ignored) {
     name = "FittingAnalyzer";
     if (s == "GSL" || s == "gsl")
         driver_ = new GslFitter();
@@ -43,6 +43,7 @@ FittingAnalyzer::FittingAnalyzer(const std::string &s) {
            << "\" was unknown. Please choose a valid driver.";
         throw GeneralException(ss.str());
     }
+    ignoredTypes_ = ignored; 
 }
 
 FittingAnalyzer::~FittingAnalyzer() {
@@ -53,6 +54,13 @@ void FittingAnalyzer::Analyze(Trace &trace, const ChannelConfiguration &cfg) {
     TraceAnalyzer::Analyze(trace, cfg);
 
     if (trace.IsSaturated() || trace.empty() || !trace.HasValidAnalysis()) {
+        trace.SetPhase(0.0);
+        EndAnalyze();
+        return;
+    }
+    if (ignoredTypes_.find(cfg.GetType()) != ignoredTypes_.end() || 
+    ignoredTypes_.find(cfg.GetType() + ":" + cfg.GetSubtype()) != ignoredTypes_.end() ||
+    ignoredTypes_.find(cfg.GetType() + ":" + cfg.GetSubtype() + ":" + cfg.GetGroup()) != ignoredTypes_.end()){
         trace.SetPhase(0.0);
         EndAnalyze();
         return;

--- a/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
@@ -19,15 +19,14 @@
 using namespace std;
 
 WaveformAnalyzer::WaveformAnalyzer(const std::set<std::string> &ignoredTypes)
-        : TraceAnalyzer() {
+    : TraceAnalyzer() {
     name = "WaveformAnalyzer";
     ignoredTypes_ = ignoredTypes;
 }
 
 void WaveformAnalyzer::Analyze(Trace &trace, const ChannelConfiguration &cfg) {
     TraceAnalyzer::Analyze(trace, cfg);
-    if (trace.IsSaturated() || trace.empty() || ignoredTypes_.find(cfg.GetType()) != ignoredTypes_.end() || ignoredTypes_.find(cfg.GetType()+":"+cfg.GetSubtype()) != ignoredTypes_.end()) {
-
+    if (trace.IsSaturated() || trace.empty() || ignoredTypes_.find(cfg.GetType()) != ignoredTypes_.end() || ignoredTypes_.find(cfg.GetType() + ":" + cfg.GetSubtype()) != ignoredTypes_.end() || ignoredTypes_.find(cfg.GetType() + ":" + cfg.GetSubtype() + ":" + cfg.GetGroup()) != ignoredTypes_.end()) {
         trace.SetHasValidAnalysis(false);
         EndAnalyze();
         return;
@@ -50,7 +49,7 @@ void WaveformAnalyzer::Analyze(Trace &trace, const ChannelConfiguration &cfg) {
     // baseline to calculate the average baseline then we're going to set
     // some of the variables to be used later to zero and end the analysis of
     // the waveform now.
-    if (max.first - range.first < TraceFunctions::minimum_baseline_length) {
+    if ((int)(max.first - range.first) < TraceFunctions::minimum_baseline_length) {
 #ifdef VERBOSE
         cout << "WaveformAnalyzer::Analyze - The low bound for the trace overlaps with the minimum bins for the"
         "baseline." << endl;

--- a/Analysis/Utkscan/core/include/Globals.hpp
+++ b/Analysis/Utkscan/core/include/Globals.hpp
@@ -45,11 +45,21 @@ public:
     ///@return The concatenation of the provided string and the Output Path
     std::string AppendOutputPath(const std::string &a) { return outputPath_ + a; }
 
-    ///@return the adc clock in seconds 
+    ///@return the adc clock in seconds
     double GetAdcClockInSeconds() const { return adcClockInSeconds_; }
 
-    ///@return the pixie clock in seconds 
+    ///@return the correct adc clock conversion factor for the given freq
+    double GetAdcClockInSeconds(const int &freq) const { 
+        return (adcClockTickToSeconds_.find(freq)->second);
+    }
+
+    ///@return the pixie clock in seconds
     double GetClockInSeconds() const { return clockInSeconds_; }
+
+    ///@return the correct clock conversion factor for the given freq
+    double GetClockInSeconds(const int &freq) const { 
+        return (clockTickToSeconds_.find(freq)->second);
+    }
 
     ///@return the configuration file
     std::string GetConfigFileName() const { return configFile_; }
@@ -60,8 +70,13 @@ public:
     ///@return the event width
     unsigned int GetEventLengthInTicks() const { return eventLengthInTicks_; }
 
-    ///@return the filter clock in seconds 
+    ///@return the filter clock in seconds
     double GetFilterClockInSeconds() const { return filterClockInSeconds_; }
+
+    ///@return the correct filter clock conversion factor for the given freq
+    double GetFilterClockInSeconds(const int &freq) const { 
+        return (filterClockTickToSeconds_.find(freq)->second);
+    }
 
     ///@return returns name of specified output file
     std::string GetOutputFileName() const { return outputFilename_; }
@@ -106,9 +121,23 @@ public:
     ///@param[in] a : The parameter that we are going to set
     void SetAdcClockInSeconds(const double &a) { adcClockInSeconds_ = a; }
 
+    ///Sets the speed Pixie-16 ADC clock in seconds sensitive to mixed frequecy setups.
+    ///@param[in] a : The parameter that we are going to set
+    ///@param[in] freq : The Frequency  associated with this conversion
+    void SetAdcClockInSeconds( const int &freq, const double &conversionFactor) {
+        adcClockTickToSeconds_.emplace(freq, conversionFactor);
+    }
+
     ///Sets the speed Pixie-16 clock in seconds.
     ///@param[in] a : The parameter that we are going to set
     void SetClockInSeconds(const double &a) { clockInSeconds_ = a; }
+
+    ///Sets the speed Pixie-16 clock in seconds sensitive to mixed frequecy setups.
+    ///@param[in] a : The parameter that we are going to set
+    ///@param[in] freq : The Frequency  associated with this conversion
+    void SetClockInSeconds( const int &freq, const double &conversionFactor) {
+        clockTickToSeconds_.emplace(freq, conversionFactor);
+    }
 
     ///Sets the event length in seconds that we will use to create events.
     ///@param[in] a : The parameter that we are going to set
@@ -120,7 +149,14 @@ public:
 
     ///Sets the Pixie-16 Filter clock value.
     ///@param[in] a : The parameter that we are going to set
-    void SetFilterClockInSeconds(const double &a) { filterClockInSeconds_ = a; }
+    void SetFilterClockInSeconds( const double &a) { filterClockInSeconds_ = a; }
+
+    ///Sets the speed Pixie-16 Filter clock in seconds sensitive to mixed frequecy setups.
+    ///@param[in] a : The parameter that we are going to set
+    ///@param[in] freq : The Frequency  associated with this conversion
+    void SetFilterClockInSeconds( const int &freq, const double &conversionFactor) {
+        filterClockTickToSeconds_.emplace(freq, conversionFactor);
+    }
 
     ///Sets a flag that controls if we output the raw histograms to DAMM
     ///@param[in] a : The parameter that we are going to set
@@ -174,21 +210,24 @@ private:
     /// they are not set properly due to invalid up configuration files.
     void InitializeMemberVariables(void);
 
-    double adcClockInSeconds_; //!< adc clock in second
-    double clockInSeconds_;//!< the ACQ clock in seconds
-    std::string configFile_; //!< The configuration file
-    double eventLengthInSeconds_;//!< event width in seconds
-    unsigned int eventLengthInTicks_; //!< the size of the events
-    double filterClockInSeconds_;//!< filter clock in seconds
-    bool hasRawHistogramsDefined_; //!< True if we are plotting Raw Histograms
-    std::string outputFilename_; //!<Output Filename
-    std::string outputPath_; //!< The path to additional configuration files
-    std::string revision_; //!< the pixie revision
-    double sysClockFreqInHz_; //!< frequency of the system clock
-    std::vector<std::pair<unsigned int, unsigned int>> reject_; ///< Rejection regions
-    double vandleBigSpeedOfLight_;//!< speed of light in big VANDLE bars in cm/ns
-    double vandleMediumSpeedOfLight_;//!< speed of light in medium VANDLE bars in cm/ns
-    double vandleSmallSpeedOfLight_;//!< speed of light in small VANDLE bars in cm/ns
+    std::map<int, double> clockTickToSeconds_;                //!< map of frequencies and conversion factors
+    std::map<int, double> adcClockTickToSeconds_;             //!< map of frequencies and conversion factors for Adc Ticks->Seconds
+    std::map<int, double> filterClockTickToSeconds_;             //!< map of frequencies and conversion factors for Dsp Ticks->Seconds
+    double adcClockInSeconds_;                                   //!< adc clock in second
+    double clockInSeconds_;                                      //!< the ACQ clock in seconds
+    std::string configFile_;                                     //!< The configuration file
+    double eventLengthInSeconds_;                                //!< event width in seconds
+    unsigned int eventLengthInTicks_;                            //!< the size of the events
+    double filterClockInSeconds_;                                //!< filter clock in seconds
+    bool hasRawHistogramsDefined_;                               //!< True if we are plotting Raw Histograms
+    std::string outputFilename_;                                 //!<Output Filename
+    std::string outputPath_;                                     //!< The path to additional configuration files
+    std::string revision_;                                       //!< the pixie revision
+    double sysClockFreqInHz_;                                    //!< frequency of the system clock
+    std::vector<std::pair<unsigned int, unsigned int>> reject_;  ///< Rejection regions
+    double vandleBigSpeedOfLight_;                               //!< speed of light in big VANDLE bars in cm/ns
+    double vandleMediumSpeedOfLight_;                            //!< speed of light in medium VANDLE bars in cm/ns
+    double vandleSmallSpeedOfLight_;                             //!< speed of light in small VANDLE bars in cm/ns
 };
 
-#endif // #ifdef _PAASS_GLOBALS_HPP_
+#endif  // #ifdef _PAASS_GLOBALS_HPP_

--- a/Analysis/Utkscan/core/include/Globals.hpp
+++ b/Analysis/Utkscan/core/include/Globals.hpp
@@ -48,17 +48,29 @@ public:
     ///@return the adc clock in seconds
     double GetAdcClockInSeconds() const { return adcClockInSeconds_; }
 
+    ///@param[in] freq : The frequency of the module
     ///@return the correct adc clock conversion factor for the given freq
-    double GetAdcClockInSeconds(const int &freq) const { 
-        return (adcClockTickToSeconds_.find(freq)->second);
+    double GetAdcClockInSeconds(const int &freq) const {
+        if (adcClockTickToSeconds_.find(freq) != adcClockTickToSeconds_.end()) {
+            return (adcClockTickToSeconds_.find(freq)->second);
+        } else {
+            std::cout << "ERROR:: Globals::GetAdcClockInSeconds(): Unknown Frequency, using Revision Default" << std::endl;
+            return adcClockInSeconds_;
+        }
     }
 
     ///@return the pixie clock in seconds
     double GetClockInSeconds() const { return clockInSeconds_; }
 
+    ///@param[in] freq : The frequency of the module
     ///@return the correct clock conversion factor for the given freq
-    double GetClockInSeconds(const int &freq) const { 
-        return (clockTickToSeconds_.find(freq)->second);
+    double GetClockInSeconds(const int &freq) const {
+        if (clockTickToSeconds_.find(freq) != clockTickToSeconds_.end()) {
+            return (clockTickToSeconds_.find(freq)->second);
+        } else {
+            std::cout << "ERROR:: Globals::GetClockInSeconds(): Unknown Frequency, using Revision Default" << std::endl;
+            return clockInSeconds_;
+        }
     }
 
     ///@return the configuration file
@@ -73,9 +85,15 @@ public:
     ///@return the filter clock in seconds
     double GetFilterClockInSeconds() const { return filterClockInSeconds_; }
 
+    ///@param[in] freq : The frequency of the module
     ///@return the correct filter clock conversion factor for the given freq
-    double GetFilterClockInSeconds(const int &freq) const { 
-        return (filterClockTickToSeconds_.find(freq)->second);
+    double GetFilterClockInSeconds(const int &freq) const {
+        if (filterClockTickToSeconds_.find(freq) != filterClockTickToSeconds_.end()) {
+            return (filterClockTickToSeconds_.find(freq)->second);
+        } else {
+            std::cout << "ERROR:: Globals::GetFilterClockInSeconds(): Unknown Frequency, using Revision Default" << std::endl;
+            return filterClockInSeconds_;
+        }
     }
 
     ///@return returns name of specified output file

--- a/Analysis/Utkscan/core/include/GlobalsXmlParser.hpp
+++ b/Analysis/Utkscan/core/include/GlobalsXmlParser.hpp
@@ -68,6 +68,10 @@ private:
 
     //A stringstream that we can use repeatedly without having to redefine.
     std::stringstream sstream_;
+
+    // list of possible Rev:F frequencies. Inner Struct is <freq,<adc factor,filter factor >>
+    // We will add the "e-9" on the set end for readability here
+    std::vector<std::pair<int, std::pair<double, double>>> revFfreq = {{100, {10, 10}}, {250, {4, 8}}, {500, {2, 10}}};
 };
 
 #endif //PAASS_XMLPARSER_HPP

--- a/Analysis/Utkscan/core/include/TreeCorrelator.hpp
+++ b/Analysis/Utkscan/core/include/TreeCorrelator.hpp
@@ -28,6 +28,10 @@ public:
     * \param [in] name : the name of the place */
     Place *place(std::string name);
 
+    /** \return bool if place defined. This is ONLY for checking the existance not accessing the place. As such it is very similar to the "place" method
+     * \param [in] name : the name of the place */
+    bool checkPlace(std::string name);
+
     /** Create place, alter or add existing place to the tree.
     * \param [in] params : the map of the parameters
     * \param [in] verbose : verbosity */

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -431,7 +431,7 @@ void DetectorDriver::FillLogicStruc() { //This should be called away from the ev
     } else {
         LogStruc.lastProtonPulseTime = TreeCorrelator::get()->place("logic_t1_0")->secondlast().time* convertTimeNS;
     }
-
+ */
     if (TreeCorrelator::get()->place("Supercycle")->status()){
         LogStruc.lastSuperCycleTime = TreeCorrelator::get()->place("Supercycle")->last().time* convertTimeNS;
     } else {

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -393,51 +393,54 @@ std::set<std::string> DetectorDriver::GetProcessorList() {
 }
 
 void DetectorDriver::FillLogicStruc() { //This should be called away from the event loops. (near where it fills the filenames)
-    double convertTimeNS = Globals::get()->GetClockInSeconds() * 1.0e9; // converstion factor from TICKs to NS
-    LogStruc.tapeCycleStatus = TreeCorrelator::get()->place("Cycle")->status();
-    LogStruc.tapeMoving =  TreeCorrelator::get()->place("TapeMove")->status();
-    LogStruc.beamStatus = TreeCorrelator::get()->place("Beam")->status();
-
-
-    if (TreeCorrelator::get()->place("Beam")->status()){
-        LogStruc.lastBeamOnTime = TreeCorrelator::get()->place("Beam")->last().time* convertTimeNS;
-        LogStruc.lastBeamOffTime = TreeCorrelator::get()->place("Beam")->secondlast().time * convertTimeNS;
-    } else {
-        LogStruc.lastBeamOnTime = TreeCorrelator::get()->place("Beam")->secondlast().time* convertTimeNS;
-        LogStruc.lastBeamOffTime = TreeCorrelator::get()->place("Beam")->last().time * convertTimeNS;
-    }
-
-    if (TreeCorrelator::get()->place("TapeMove")->status()){
-        LogStruc.lastTapeMoveStartTime = TreeCorrelator::get()->place("TapeMove")->last().time* convertTimeNS;
-    } else {
-        LogStruc.lastTapeMoveStartTime = TreeCorrelator::get()->place("TapeMove")->secondlast().time* convertTimeNS;
-    }
-
-    if (TreeCorrelator::get()->place("Cycle")->status()){
-        double currentTime_ = TreeCorrelator::get()->place("Cycle")->last().time* convertTimeNS;
-        if (currentTime_ != lastCycleTime_){
-            tapeCycleNum_++;
+    double convertTimeNS = Globals::get()->GetClockInSeconds() * 1.0e9; // converstion factor from DSP TICKs to NS
+   
+    if(TreeCorrelator::get()->checkPlace("Beam")){
+        LogStruc.beamStatus = TreeCorrelator::get()->place("Beam")->status();
+        if (TreeCorrelator::get()->place("Beam")->status()){
+            LogStruc.lastBeamOnTime = TreeCorrelator::get()->place("Beam")->last().time* convertTimeNS;
+            LogStruc.lastBeamOffTime = TreeCorrelator::get()->place("Beam")->secondlast().time * convertTimeNS;
+        } else {
+            LogStruc.lastBeamOnTime = TreeCorrelator::get()->place("Beam")->secondlast().time* convertTimeNS;
+            LogStruc.lastBeamOffTime = TreeCorrelator::get()->place("Beam")->last().time * convertTimeNS;
         }
-        LogStruc.lastTapeCycleStartTime = currentTime_;
-        LogStruc.cycleNum = tapeCycleNum_;
-    } else {
-        LogStruc.lastTapeCycleStartTime = TreeCorrelator::get()->place("Cycle")->secondlast().time* convertTimeNS;
-         LogStruc.cycleNum = tapeCycleNum_;
     }
 
-    LogStruc.lastProtonPulseTime = TreeCorrelator::get()->place("Protons")->last().time*convertTimeNS;
-  /*   if (TreeCorrelator::get()->place("logic_t1_0")->status()){
-        LogStruc.lastProtonPulseTime = TreeCorrelator::get()->place("logic_t1_0")->last().time* convertTimeNS;
-    } else {
-        LogStruc.lastProtonPulseTime = TreeCorrelator::get()->place("logic_t1_0")->secondlast().time* convertTimeNS;
-    }
- */
-    if (TreeCorrelator::get()->place("Supercycle")->status()){
-        LogStruc.lastSuperCycleTime = TreeCorrelator::get()->place("Supercycle")->last().time* convertTimeNS;
-    } else {
-        LogStruc.lastSuperCycleTime = TreeCorrelator::get()->place("Supercycle")->secondlast().time* convertTimeNS;
+    if(TreeCorrelator::get()->checkPlace("TapeMove")){
+        LogStruc.tapeMoving =  TreeCorrelator::get()->place("TapeMove")->status();
+        if (TreeCorrelator::get()->place("TapeMove")->status()){
+            LogStruc.lastTapeMoveStartTime = TreeCorrelator::get()->place("TapeMove")->last().time* convertTimeNS;
+        } else {
+            LogStruc.lastTapeMoveStartTime = TreeCorrelator::get()->place("TapeMove")->secondlast().time* convertTimeNS;
+        }
     }
 
+    if(TreeCorrelator::get()->checkPlace("Cycle")){
+        LogStruc.tapeCycleStatus = TreeCorrelator::get()->place("Cycle")->status();
+        if (TreeCorrelator::get()->place("Cycle")->status()){
+            double currentTime_ = TreeCorrelator::get()->place("Cycle")->last().time* convertTimeNS;
+            if (currentTime_ != lastCycleTime_){
+                tapeCycleNum_++;
+            }
+            LogStruc.lastTapeCycleStartTime = currentTime_;
+            LogStruc.cycleNum = tapeCycleNum_;
+        } else {
+            LogStruc.lastTapeCycleStartTime = TreeCorrelator::get()->place("Cycle")->secondlast().time* convertTimeNS;
+            LogStruc.cycleNum = tapeCycleNum_;
+        }
+    }
+    
+    if(TreeCorrelator::get()->checkPlace("Protons") && TreeCorrelator::get()->place("Protons")->status()){
+        LogStruc.lastProtonPulseTime = TreeCorrelator::get()->place("Protons")->last().time*convertTimeNS;
+    }
+    
+    if (TreeCorrelator::get()->checkPlace("Supercycle") ){
+        if (TreeCorrelator::get()->place("Supercycle")->status()){
+            LogStruc.lastSuperCycleTime = TreeCorrelator::get()->place("Supercycle")->last().time* convertTimeNS;
+        } else {
+            LogStruc.lastSuperCycleTime = TreeCorrelator::get()->place("Supercycle")->secondlast().time* convertTimeNS;
+        }
+    }
     //fill the vector
     pixie_tree_event_.logic_vec_.emplace_back(LogStruc);
 }

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -422,9 +422,11 @@ void DetectorDriver::FillLogicStruc() { //This should be called away from the ev
         LogStruc.cycleNum = tapeCycleNum_;
     } else {
         LogStruc.lastTapeCycleStartTime = TreeCorrelator::get()->place("Cycle")->secondlast().time* convertTimeNS;
+         LogStruc.cycleNum = tapeCycleNum_;
     }
 
-    if (TreeCorrelator::get()->place("logic_t1_0")->status()){
+    LogStruc.lastProtonPulseTime = TreeCorrelator::get()->place("Protons")->last().time*convertTimeNS;
+  /*   if (TreeCorrelator::get()->place("logic_t1_0")->status()){
         LogStruc.lastProtonPulseTime = TreeCorrelator::get()->place("logic_t1_0")->last().time* convertTimeNS;
     } else {
         LogStruc.lastProtonPulseTime = TreeCorrelator::get()->place("logic_t1_0")->secondlast().time* convertTimeNS;

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -68,7 +68,7 @@ DetectorDriver::DetectorDriver() : histo(OFFSET, RANGE, "DetectorDriver") {
             setProcess.emplace((*it)->GetName());
         }
         if (setProcess.empty()){
-            throw GeneralException("Exception:DetectorDriver:: setProcess is empty and root requested. this will cause segfaults on root fill()");
+            throw GeneralException("Exception:DetectorDriver:: setProcess is empty and root requested. This will cause segfaults on root Fill()");
 
         }
 

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -43,6 +43,7 @@ DetectorDriver::DetectorDriver() : histo(OFFSET, RANGE, "DetectorDriver") {
     sysrootbool_ = false;
     fillLogic_  = false;
     tapeCycleNum_ = 0;
+    lastCycleTime_ = 0;
 
     try {
         DetectorDriverXmlParser parser;
@@ -420,6 +421,7 @@ void DetectorDriver::FillLogicStruc() { //This should be called away from the ev
         if (TreeCorrelator::get()->place("Cycle")->status()){
             double currentTime_ = TreeCorrelator::get()->place("Cycle")->last().time* convertTimeNS;
             if (currentTime_ != lastCycleTime_){
+                lastCycleTime_ = currentTime_;
                 tapeCycleNum_++;
             }
             LogStruc.lastTapeCycleStartTime = currentTime_;

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -42,6 +42,7 @@
 #include "NeutronScintProcessor.hpp"
 #include "PositionProcessor.hpp"
 #include "PspmtProcessor.hpp"
+#include "RootDevProcessor.hpp"
 #include "TeenyVandleProcessor.hpp"
 #include "TemplateProcessor.hpp"
 #include "VandleProcessor.hpp"
@@ -205,11 +206,15 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
                     processor.attribute("front_threshold").as_double(50.0),
                     processor.attribute("rotation").as_double(0.0)
             ));
-        } else if (name == "TeenyVandleProcessor") {
+        } else if (name =="RootDevProcessor"){
+            vecProcess.push_back(new RootDevProcessor());
+        }else if (name == "TeenyVandleProcessor") {
             vecProcess.push_back(new TeenyVandleProcessor());
         } else if (name == "TemplateProcessor") {
             vecProcess.push_back(new TemplateProcessor());
-        } else if (name == "VandleProcessor") {
+        }else if (name == "TemplateExpProcessor") {
+            vecProcess.push_back(new TemplateExpProcessor());
+        }else if (name == "VandleProcessor") {
             vecProcess.push_back(new VandleProcessor(
                     StringManipulation::TokenizeString(processor.attribute("types").as_string("medium"), ","),
                     processor.attribute("res").as_double(2.0), processor.attribute("offset").as_double(1000.0),

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -177,7 +177,7 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
         } else if (name == "LitePositionProcessor") {
             vecProcess.push_back(new LitePositionProcessor());
         } else if (name == "LogicProcessor") {
-            vecProcess.push_back(new LogicProcessor());
+            vecProcess.push_back(new LogicProcessor(processor.attribute("double_stop").as_bool(false),processor.attribute("double_start").as_bool(false)));
         } else if (name == "McpProcessor") {
             vecProcess.push_back(new McpProcessor());
         } else if (name == "NeutronScintProcessor") {

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -258,7 +258,8 @@ vector<TraceAnalyzer *> DetectorDriverXmlParser::ParseAnalyzers(const pugi::xml_
         if (name == "CfdAnalyzer") {
             vecAnalyzer.push_back(new CfdAnalyzer(analyzer.attribute("type").as_string("poly")));
         } else if (name == "FittingAnalyzer") {
-            vecAnalyzer.push_back(new FittingAnalyzer(analyzer.attribute("type").as_string("gsl")));
+            std::vector<std::string> tokens = StringManipulation::TokenizeString(analyzer.attribute("ignored").as_string(""), ",");
+            vecAnalyzer.push_back(new FittingAnalyzer(analyzer.attribute("type").as_string("gsl"),std::set<std::string>(tokens.begin(), tokens.end())));
         } else if (name == "TauAnalyzer") {
             vecAnalyzer.push_back(new TauAnalyzer());
         } else if (name == "TraceExtractor") {

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -188,7 +188,10 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
         } else if (name == "LitePositionProcessor") {
             vecProcess.push_back(new LitePositionProcessor());
         } else if (name == "LogicProcessor") {
-            vecProcess.push_back(new LogicProcessor(processor.attribute("double_stop").as_bool(false),processor.attribute("double_start").as_bool(false)));
+            vecProcess.push_back(new LogicProcessor(
+                processor.attribute("double_stop").as_bool(false),
+                processor.attribute("double_start").as_bool(false)
+                ));
         } else if (name == "McpProcessor") {
             vecProcess.push_back(new McpProcessor());
         } else if (name == "NeutronScintProcessor") {
@@ -219,7 +222,7 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
                     StringManipulation::TokenizeString(processor.attribute("types").as_string("medium"), ","),
                     processor.attribute("res").as_double(2.0), processor.attribute("offset").as_double(1000.0),
                     processor.attribute("NumStarts").as_uint(1), processor.attribute("compression").as_double(1.0),
-                    processor.attribute("qdcmin").as_double(0.0),processor.attribute("tofcut").as_double(-1000.0)));
+                    processor.attribute("qdcmin").as_double(0.0),processor.attribute("tofcut").as_double(-1000.0),processor.attribute("idealfp").as_double(100)));
         } 
 #ifdef useroot //Certain processors REQUIRE ROOT to actually work
         else if (name == "Anl1471Processor") {

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -29,6 +29,7 @@
 #include "CloverFragProcessor.hpp"
 #include "DoubleBetaProcessor.hpp"
 #include "DssdProcessor.hpp"
+#include "ExtTSSenderProcessor.hpp"
 #include "GammaScintProcessor.hpp"
 #include "GeProcessor.hpp"
 #include "Hen3Processor.hpp"
@@ -44,7 +45,6 @@
 #include "TeenyVandleProcessor.hpp"
 #include "TemplateProcessor.hpp"
 #include "VandleProcessor.hpp"
-#include "ExtTSSenderProcessor.hpp"
 
 //These headers are for handling experiment specific processing.
 #include "E11027Processor.hpp"
@@ -131,6 +131,16 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
             vecProcess.push_back(new DoubleBetaProcessor());
         } else if (name == "DssdProcessor") {
             vecProcess.push_back(new DssdProcessor());
+              } else if (name == "E11027Processor") {
+            vecProcess.push_back(new E11027Processor());
+        }else if (name == "ExtTSSenderProcessor") {
+            vecProcess.push_back(new ExtTSSenderProcessor(
+                    processor.attribute("type").as_string(""),
+                    processor.attribute("host").as_string("localhost"),
+                    processor.attribute("slot").as_int(0),
+                    processor.attribute("channel").as_int(0),
+                    processor.attribute("port").as_int(12345),
+                    processor.attribute("buffSize").as_uint(64)));
         }else if (name == "GammaScintProcessor") {
             std::map<std::string,std::string> GScintArgs;
             std::string defaultSubEvtWin = "0.50e-6";
@@ -205,21 +215,7 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
                     processor.attribute("res").as_double(2.0), processor.attribute("offset").as_double(1000.0),
                     processor.attribute("NumStarts").as_uint(1), processor.attribute("compression").as_double(1.0),
                     processor.attribute("qdcmin").as_double(0.0),processor.attribute("tofcut").as_double(-1000.0)));
-        } else if (name == "TemplateExpProcessor") {
-            vecProcess.push_back(new TemplateExpProcessor());
-        } else if (name == "E11027Processor") {
-            vecProcess.push_back(new E11027Processor());
-        } else if (name == "TemplateExpProcessor") {
-            vecProcess.push_back(new TemplateExpProcessor());
-        } else if (name == "ExtTSSenderProcessor") {
-            vecProcess.push_back(new ExtTSSenderProcessor(
-                    processor.attribute("type").as_string(""),
-                    processor.attribute("host").as_string("localhost"),
-                    processor.attribute("slot").as_int(0),
-                    processor.attribute("channel").as_int(0),
-                    processor.attribute("port").as_int(12345),
-                    processor.attribute("buffSize").as_uint(64)));
-        }
+        } 
 #ifdef useroot //Certain processors REQUIRE ROOT to actually work
         else if (name == "Anl1471Processor") {
             vecProcess.push_back(new Anl1471Processor());

--- a/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
@@ -79,10 +79,21 @@ void GlobalsXmlParser::ParseGlobalNode(const pugi::xml_node &node, Globals *glob
             globals->SetClockInSeconds(10e-9);
             globals->SetFilterClockInSeconds(10e-9);
         } else if (revision == "F") {
-            // Not all RevFs are 250MHz and this should not be a single value since we can boot Mixed Crates (T.T. King Feb 7, 2019)
+            // Users of mixed crates are expected to pass the correct freq to the Get...Clock() functions
+            // For legacy/ compatibility reasons we will default Rev F to 250 MHz
             globals->SetAdcClockInSeconds(4e-9);
             globals->SetClockInSeconds(8e-9);
             globals->SetFilterClockInSeconds(8e-9);
+
+            for (int it=0;it<(int)revFfreq.size();it++){
+                int curFreq = revFfreq.at(it).first;
+                double adcFactor = revFfreq.at(it).second.first * pow(10,-9);
+                double filterFactor = revFfreq.at(it).second.second * pow(10,-9);
+                globals->SetAdcClockInSeconds(curFreq,adcFactor);
+                globals->SetClockInSeconds(curFreq,filterFactor);
+                globals->SetFilterClockInSeconds(curFreq,filterFactor);
+            }
+
         } else {
             throw invalid_argument("GlobalsXmlParser::ParseGlobal - The revision \"" + revision +
                                            "\", is not known to us. Known revisions are A, D, F");

--- a/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
@@ -46,6 +46,11 @@ void GlobalsXmlParser::ParseNode(Globals *globals) {
             m.start("Loading Vandle Node");
             ParseVandleNode(root.child("Vandle"), globals);
             m.done();
+        }else{
+            //always set the normal constants. The current setup will always set the values while allowing single type overrides 
+            globals->SetVandleBigSpeedOfLight(15.22998);
+            globals->SetVandleMediumSpeedOfLight(15.5);
+            globals->SetVandleSmallSpeedOfLight(12.65822);
         }
     } catch (exception &e) {
         m.detail("Globals::Globals : Exception caught while parsing configuration file.");

--- a/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/GlobalsXmlParser.cpp
@@ -74,6 +74,7 @@ void GlobalsXmlParser::ParseGlobalNode(const pugi::xml_node &node, Globals *glob
             globals->SetClockInSeconds(10e-9);
             globals->SetFilterClockInSeconds(10e-9);
         } else if (revision == "F") {
+            // Not all RevFs are 250MHz and this should not be a single value since we can boot Mixed Crates (T.T. King Feb 7, 2019)
             globals->SetAdcClockInSeconds(4e-9);
             globals->SetClockInSeconds(8e-9);
             globals->SetFilterClockInSeconds(8e-9);

--- a/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
@@ -96,6 +96,7 @@ void MapNodeXmlParser::ParseNode(DetectorLibrary *lib) {
             chanCfg.SetType(channel.attribute("type").as_string("ignore"));
             chanCfg.SetSubtype(channel.attribute("subtype").as_string("ignore"));
             chanCfg.SetGroup(channel.attribute("group").as_string("ignore"));
+            chanCfg.SetModFreq(module_freq);
 
             if (channel.attribute("location").as_int(-1) == -1)
                 chanCfg.SetLocation(lib->GetNextLocation(chanCfg.GetType(), chanCfg.GetSubtype()));

--- a/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
@@ -250,7 +250,7 @@ void MapNodeXmlParser::ParseTraceNode(const pugi::xml_node &node, ChannelConfigu
 
     if(isVerbose) {
         sstream_.str("");
-        sstream_ << "Trace Delay (ns)= " << mod_TD;
+        sstream_ << "Trace Delay (ns)= " << TraceDelay;
         sstream_ << "   Trace Delay (sample)= " << TDsample;
         messenger_.detail(sstream_.str(), 2);
         sstream_.str("");

--- a/Analysis/Utkscan/core/source/TreeCorrelator.cpp
+++ b/Analysis/Utkscan/core/source/TreeCorrelator.cpp
@@ -35,6 +35,17 @@ Place *TreeCorrelator::place(std::string name) {
     return element->second;
 }
 
+bool TreeCorrelator::checkPlace(std::string name) {
+    map<string, Place *>::iterator element = places_.find(name);
+    bool status;
+    if (element == places_.end()) {
+        status = false;
+    } else {
+        status = true; 
+    } 
+    return status;
+} 
+
 void TreeCorrelator::addChild(std::string parent, std::string child, bool coin, bool verbose) {
     if (places_.count(parent) == 1 && places_.count(child) == 1) {
         place(parent)->addChild(place(child), coin);

--- a/Analysis/Utkscan/processors/include/LogicProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/LogicProcessor.hpp
@@ -16,13 +16,10 @@ public:
     /** Default Constructor */
     LogicProcessor();
 
-    /** Constructor taking histogram offset and range as arguments
-    * \param [in] offset : the offset of the histograms
-    * \param [in] range : the maximum number of histograms 
+    /** Constructor taking double_start and double_stop
     * \param [in] doubleStop : if we have doubled the stops in the map
     * \param [in] doubleStart : if we have doubled the starts in the map */
-    LogicProcessor(int offset, int range, bool doubleStop = false,
-                   bool doubleStart = false);
+    LogicProcessor(bool doubleStop = false, bool doubleStart = false);
 
     /** Declare plots used in the analysis */
     virtual void DeclarePlots(void);

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -8,93 +8,111 @@
 #include <TString.h>
 
 namespace processor_struct {
-    struct VANDLES {
-        double tof=0;
-        double corTof=0;
-        double qdcPos=0;
-        double qdc=0;
-        int barNum=0;
-        std::string barType="";
-        double tdiff=-999;
-        unsigned int sNum =0; //start detector number
-        int vMulti=0;
-        double sTime = -999;
-        double sQdc = -999;
 
-    } ;
-    static const VANDLES  VANDLES_DEFAULT_STRUCT;
-    
-    struct GAMMASCINT{
-        double energy = -999;
-        double rawEnergy = -999;
-        bool isDynodeOut = false;
-        int detNum = -999;
-        double time = -999;
-        TString group = "";
-        TString subtype = "";
-    } ;
-    static const GAMMASCINT GAMMASCINT_DEFAULT_STRUCT;
+struct CLOVERS {
+    double energy = -999;
+    double rawEnergy = -999;
+    double time = -999;
+    int detNum = -999;
+    int cloverNum = -999;
+};
 
-    struct DOUBLEBETA{
-        int detNum = -999;
-        double energy = -999;
-        double rawEnergy = -999;
-        double timeAvg = -999;
-        double timeDiff = -999;
-        double timeL = -999;
-        double timeR = -999;
-        double barQdc = -999;
-        double tMaxValL = -999;
-        double tMaxValR = -999;
-        bool isLowResBeta = false;
-        bool isHighResBeta = false;
-    };
-    static const DOUBLEBETA DOUBLEBETA_DEFAULT_STRUCT;
+static const CLOVERS CLOVERS_DEFAULT_STRUCT;
 
-    struct CLOVERS{
-        double energy = -999;
-        double rawEnergy =-999;
-        double time = -999;
-        int detNum = -999;
-        int cloverNum = -999;
-    };
+struct DOUBLEBETA {
+    int detNum = -999;
+    double energy = -999;
+    double rawEnergy = -999;
+    double timeAvg = -999;
+    double timeDiff = -999;
+    double timeL = -999;
+    double timeR = -999;
+    double barQdc = -999;
+    double tMaxValL = -999;
+    double tMaxValR = -999;
+    bool isLowResBeta = false;
+    bool isHighResBeta = false;
+};
+static const DOUBLEBETA DOUBLEBETA_DEFAULT_STRUCT;
 
-    static const CLOVERS CLOVERS_DEFAULT_STRUCT;
+struct GAMMASCINT {
+    double energy = -999;
+    double rawEnergy = -999;
+    bool isDynodeOut = false;
+    int detNum = -999;
+    double time = -999;
+    TString group = "";
+    TString subtype = "";
+};
+static const GAMMASCINT GAMMASCINT_DEFAULT_STRUCT;
 
-    struct LOGIC{
-        bool tapeCycleStatus = false;
-        bool beamStatus= false;
-        bool tapeMoving = false;
+struct LOGIC {
+    bool tapeCycleStatus = false;
+    bool beamStatus = false;
+    bool tapeMoving = false;
 
-        double lastTapeCycleStartTime = -999;
-        double lastBeamOnTime = -999;
-        double lastBeamOffTime = -999;
-        double lastTapeMoveStartTime = -999;
-        double lastProtonPulseTime = -999;
-        double lastSuperCycleTime = -999;
+    double lastTapeCycleStartTime = -999;
+    double lastBeamOnTime = -999;
+    double lastBeamOffTime = -999;
+    double lastTapeMoveStartTime = -999;
+    double lastProtonPulseTime = -999;
+    double lastSuperCycleTime = -999;
 
-        double cycleNum = -999;
-    };
-    static const LOGIC LOGIC_DEFAULT_STRUCT;
+    int cycleNum = -999;
+};
+static const LOGIC LOGIC_DEFAULT_STRUCT;
 
-    struct PSPMT { 
-        double energy = -999;
-        double time = -999;
-        TString subtype = "";
-        TString tag = "";
-    };
-    static const PSPMT  PSPMT_DEFAULT_STRUCT;
-}    
+struct PSPMT {
+    double energy = -999;
+    double time = -999;
+    TString subtype = "";
+    TString tag = "";
+};
+static const PSPMT PSPMT_DEFAULT_STRUCT;
 
-class PixTreeEvent : public TObject
-{
-public:
+struct ROOTDEV {
+    double energy = -999;
+    double rawEnergy = -999;
+    double timeSansCfd = -999;
+    double time = -999;
+    int detNum = -999;                       //the instance number of RD in the xml Map
+     int modNum = -999;                       // the physical module number
+    int chanNum = -999;                      // the physical channel number
+    TString subtype = "";                    
+    TString group = "";                      
+    bool pileup = false;                     //Did pixie detect pileup in the event
+    bool saturation = false;                 //Did the trace go out of the ADC range
+    std::vector<unsigned int> trace = {};    //The trace if present
+    double tqdc = -999;                      //QDC from trace (requires the Waveform Analyzer)
+    int maxPos = -999;                       //Max location in the trace  (requires the Waveform Analyzer)
+    double maxVal = -999;                    //Max value in the trace (requires the Waveform Analyzer)
+    double highResTime = -999;               //High Resolution Time derived from the trace fitting (requires the Waveform and Fitting Analyzer)
+    std::vector<unsigned int> qdcSums = {};  //output the onboard qdc sums if present
+};
+static const ROOTDEV ROOTDEV_DEFAULT_STRUCT;
 
-    PixTreeEvent(){}
+struct VANDLES {
+    double tof = 0;
+    double corTof = 0;
+    double qdcPos = 0;
+    double qdc = 0;
+    int barNum = 0;
+    std::string barType = "";
+    double tdiff = -999;
+    unsigned int sNum = 0;  //start detector number
+    int vMulti = 0;
+    double sTime = -999;
+    double sQdc = -999;
+};
+static const VANDLES VANDLES_DEFAULT_STRUCT;
+}  // namespace processor_struct
+
+class PixTreeEvent : public TObject {
+   public:
+    PixTreeEvent() {}
 
     /* copy constructor */
-    PixTreeEvent( const PixTreeEvent &obj ):TObject(obj)
-    {
+    PixTreeEvent(const PixTreeEvent &obj) : TObject(obj) {
         externalTS1 = obj.externalTS1;
         externalTS2 = obj.externalTS2;
         eventNum = obj.eventNum;
@@ -104,14 +122,14 @@ public:
         gamma_scint_vec_ = obj.gamma_scint_vec_;
         logic_vec_ = obj.logic_vec_;
         pspmt_vec_ = obj.pspmt_vec_;
+        root_dev_vec_ = obj.root_dev_vec_;
         vandle_vec_ = obj.vandle_vec_;
     }
 
-    virtual ~PixTreeEvent(){}
+    virtual ~PixTreeEvent() {}
 
     /* clear vectors and init all the values */
-    virtual void Clear()
-    {
+    virtual void Clear() {
         externalTS1 = 0;
         externalTS2 = 0;
         eventNum = 0;
@@ -121,8 +139,8 @@ public:
         gamma_scint_vec_.clear();
         logic_vec_.clear();
         pspmt_vec_.clear();
+        root_dev_vec_.clear();
         vandle_vec_.clear();
-
     }
 
     /* data structures to be filled in the ROOT TTree */
@@ -135,9 +153,10 @@ public:
     std::vector<processor_struct::GAMMASCINT> gamma_scint_vec_;
     std::vector<processor_struct::LOGIC> logic_vec_;
     std::vector<processor_struct::PSPMT> pspmt_vec_;
+    std::vector<processor_struct::ROOTDEV> root_dev_vec_;
     std::vector<processor_struct::VANDLES> vandle_vec_;
 
-    ClassDef(PixTreeEvent,1)
+    ClassDef(PixTreeEvent, 1)
 };
 
-#endif //PAASS_PROCESSORSTRUC_HPP
+#endif  //PAASS_PROCESSORSTRUC_HPP

--- a/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
+++ b/Analysis/Utkscan/processors/include/ProcessorRootStruc.hpp
@@ -67,6 +67,11 @@ struct PSPMT {
     double time = -999;
     TString subtype = "";
     TString tag = "";
+    double traceMaxVal = -999;
+    int traceMaxPos = -999;
+    double preBaseAvg = -999;
+    double postBaseAvg = -999;
+    bool invalidTrace = false;
 };
 static const PSPMT PSPMT_DEFAULT_STRUCT;
 
@@ -75,11 +80,11 @@ struct ROOTDEV {
     double rawEnergy = -999;
     double timeSansCfd = -999;
     double time = -999;
-    int detNum = -999;                       //the instance number of RD in the xml Map
-     int modNum = -999;                       // the physical module number
-    int chanNum = -999;                      // the physical channel number
-    TString subtype = "";                    
-    TString group = "";                      
+    int detNum = -999;   //the instance number of RD in the xml Map
+    int modNum = -999;   // the physical module number
+    int chanNum = -999;  // the physical channel number
+    TString subtype = "";
+    TString group = "";
     bool pileup = false;                     //Did pixie detect pileup in the event
     bool saturation = false;                 //Did the trace go out of the ADC range
     std::vector<unsigned int> trace = {};    //The trace if present

--- a/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/PspmtProcessor.hpp
@@ -78,6 +78,8 @@ private:
     std::pair<double, double> CalculatePosition(double &xa, double &xb, double &ya,
                                                 double &yb, const VDTYPES &vdtype, double &rot);
 
+    ///@brief A method to fill PSStruc members. Trace analysis is also implementd here.
+    void FillPSPMTStruc(const ChanEvent &chan_event);
 
     VDTYPES vdtype_; ///< Local variable to store the type of voltage divider
     ///< we're using.

--- a/Analysis/Utkscan/processors/include/RootDevProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/RootDevProcessor.hpp
@@ -1,0 +1,37 @@
+/**@file RootDevProcessor.hpp
+*@brief  Basic ROOT output. Fills a generic struc in the same tree layout as the other processors. It has NO damm output
+*@authors T.T. King 
+*@date 03/30/2019
+*/
+#ifndef PAASS_RootDevProcessor_H
+#define PAASS_RootDevProcessor_H
+
+#include "EventProcessor.hpp"
+#include "ProcessorRootStruc.hpp"
+#include "RawEvent.hpp"
+
+class RootDevProcessor : public EventProcessor {
+   public:
+    /**Constructor */
+    RootDevProcessor();
+
+    /** Deconstructor */
+    ~RootDevProcessor() = default;
+
+    /** Preprocess the event
+    * \param [in] event : the event to preprocess
+    * \return true if successful
+    */
+    virtual bool PreProcess(RawEvent &event);
+
+    /** Process the event
+     * \param [in] event : the event to process
+     * \return true if successful
+     */
+    virtual bool Process(RawEvent &event);
+
+   private:
+    processor_struct::ROOTDEV RDstruct;  //!<Root Struct
+};
+
+#endif  //PAASS_RootDevProcessor_H

--- a/Analysis/Utkscan/processors/include/RootDevProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/RootDevProcessor.hpp
@@ -32,6 +32,7 @@ class RootDevProcessor : public EventProcessor {
 
    private:
     processor_struct::ROOTDEV RDstruct;  //!<Root Struct
+    std::string Rev;
 };
 
 #endif  //PAASS_RootDevProcessor_H

--- a/Analysis/Utkscan/processors/include/SysRootLinkDef.hpp
+++ b/Analysis/Utkscan/processors/include/SysRootLinkDef.hpp
@@ -22,6 +22,9 @@
 #pragma link C++ struct processor_struct::PSPMT+;
 #pragma link C++ class std::vector<processor_struct::PSPMT>+;
 
+#pragma link C++ struct processor_struct::ROOTDEV+;
+#pragma link C++ class std::vector<processor_struct::ROOTDEV>+;
+
 #pragma link C++ struct processor_struct::VANDLES+;
 #pragma link C++ class std::vector<processor_struct::VANDLES>+;
 

--- a/Analysis/Utkscan/processors/include/VandleProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/VandleProcessor.hpp
@@ -42,7 +42,7 @@ public:
     ///@param [in] numStarts : number of starts we have to process */
     VandleProcessor(const std::vector<std::string> &typeList, const double &res, const double &offset,
                     const unsigned int &numStarts, const double &compression , const double &qdcmin,
-                    const double &tofcut);
+                    const double &tofcut, const double &idealFP);
 
     ///Preprocess the VANDLE data
     ///@param [in] event : the event to preprocess
@@ -104,6 +104,7 @@ private:
     double plotMult_;//!< The resolution multiplier for DAMM histograms
     double plotOffset_;//!< The offset multiplier for DAMM histograms
     double qdcComp_; //!<QDC compression value as read from the config file
+    double idealFP_; //!<Ideal Flight Path to correct the Tof to. 
 
     double qdcmin_;//!<min qdc to add to root tree, used to help speed up nearline mergers etc
     double tofcut_;//!< min tof to add to root tree for speeding up near line merger

--- a/Analysis/Utkscan/processors/source/CMakeLists.txt
+++ b/Analysis/Utkscan/processors/source/CMakeLists.txt
@@ -20,6 +20,7 @@ set(PROCESSOR_SOURCES
         NeutronScintProcessor.cpp
         PositionProcessor.cpp
         PspmtProcessor.cpp
+        RootDevProcessor.cpp
         TeenyVandleProcessor.cpp
         TemplateProcessor.cpp
         VandleProcessor.cpp

--- a/Analysis/Utkscan/processors/source/CloverFragProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/CloverFragProcessor.cpp
@@ -159,7 +159,7 @@ bool CloverFragProcessor::Process(RawEvent &event) {
             //Fill root struct and push back on to vector
             Cstruct.rawEnergy = (*itClover)->GetEnergy();
             Cstruct.energy = gEnergy;
-            Cstruct.time = (*itClover)->GetTimeSansCfd();
+            Cstruct.time = (*itClover)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
             Cstruct.detNum = (*itClover)->GetChanID().GetLocation();
             Cstruct.cloverNum = cloverNum;
             pixie_tree_event_->clover_vec_.emplace_back(Cstruct);

--- a/Analysis/Utkscan/processors/source/CloverProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/CloverProcessor.cpp
@@ -17,6 +17,7 @@
 #include "pugixml.hpp"
 
 #include "DammPlotIds.hpp"
+#include "DetectorDriver.hpp"
 #include "DetectorLibrary.hpp"
 #include "Display.h"
 #include "Exceptions.hpp"
@@ -529,16 +530,15 @@ bool CloverProcessor::Process(RawEvent &event) {
 
         plot(D_NONCYCGATEDENERGY, gEnergy);
 
-        Cstruct.rawEnergy = itC->GetEnergy();
-        Cstruct.energy = itC->GetCalibratedEnergy();
-        Cstruct.time = itC->GetTimeSansCfd();
-        Cstruct.detNum = itC->GetChanID().GetLocation();
-        Cstruct.cloverNum = leafToClover[itC->GetChanID().GetLocation()];
-        pixie_tree_event_->clover_vec_.emplace_back(Cstruct);
-        Cstruct = processor_struct::CLOVERS_DEFAULT_STRUCT; //reset to initalized values (see ProcessorRootStruc.hpp
-
-        //Dont fill because we want 1 pixie event per tree entry, so we add the current structure in the last spot
-        //on a vector<> and then reset the structure. and we will at the end of Process()
+        if (DetectorDriver::get()->GetSysRootOutput()){
+            Cstruct.rawEnergy = itC->GetEnergy();
+            Cstruct.energy = itC->GetCalibratedEnergy();
+            Cstruct.time = itC->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
+            Cstruct.detNum = itC->GetChanID().GetLocation();
+            Cstruct.cloverNum = leafToClover[itC->GetChanID().GetLocation()];
+            pixie_tree_event_->clover_vec_.emplace_back(Cstruct);
+            Cstruct = processor_struct::CLOVERS_DEFAULT_STRUCT; //reset to initalized values (see ProcessorRootStruc.hpp
+        }
     }
 
 

--- a/Analysis/Utkscan/processors/source/DoubleBetaProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/DoubleBetaProcessor.cpp
@@ -68,7 +68,7 @@ bool DoubleBetaProcessor::PreProcess(RawEvent &event) {
             DBstruc.isLowResBeta = true;
             DBstruc.detNum = (*it).first;
             DBstruc.energy = (*it).second.second;
-            DBstruc.timeAvg = (*it).second.first * Globals::get()->GetClockInSeconds() *1.0e9; //record time in ns
+            DBstruc.timeAvg = (*it).second.first * Globals::get()->GetAdcClockInSeconds() *1.0e9; //record time in ns, LRTBarMap uses the Walkcorrected Time which uses GetTime()
             pixie_tree_event_->doublebeta_vec_.emplace_back(DBstruc);
             DBstruc = processor_struct::DOUBLEBETA_DEFAULT_STRUCT;
         }

--- a/Analysis/Utkscan/processors/source/ExtTSSenderProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/ExtTSSenderProcessor.cpp
@@ -47,7 +47,7 @@ bool ExtTSSenderProcessor::Process(RawEvent &event)
 
     static const std::vector<ChanEvent *> &chEvents = event.GetEventList();
     for( auto chEvent : chEvents ) {
-        if( chEvent->GetChannelNumber() == chanNum_ && chEvent->GetModuleNumber() == slotNum_ ){
+        if( (int)chEvent->GetChannelNumber() == chanNum_ && (int)chEvent->GetModuleNumber() == slotNum_ ){
             unsigned long long ts = chEvent->GetExternalTimeStamp();
             // printf("ts %llu \n", ts);
             SetTS(ts);

--- a/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/GammaScintProcessor.cpp
@@ -341,11 +341,8 @@ bool GammaScintProcessor::Process(RawEvent &event) {
         }
 
         if (SysRoot_) {
-
-
             if ((*it)->GetChanID().HasTag("dy"))
                 Gsing.isDynodeOut = true;
-
             Gsing.group = (*it)->GetChanID().GetGroup();
             Gsing.subtype = (*it)->GetChanID().GetSubtype() ;
 

--- a/Analysis/Utkscan/processors/source/LogicProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/LogicProcessor.cpp
@@ -128,7 +128,7 @@ bool LogicProcessor::PreProcess(RawEvent &event) {
         string place = (*it)->GetChanID().GetPlaceName();
         string subtype = chan->GetChanID().GetSubtype();
         unsigned int loc = chan->GetChanID().GetLocation();
-        double time = chan->GetTime();
+        double time = chan->GetTimeSansCfd();
 
         static double t0 = time;
 

--- a/Analysis/Utkscan/processors/source/LogicProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/LogicProcessor.cpp
@@ -67,8 +67,8 @@ LogicProcessor::LogicProcessor(void) : EventProcessor(dammIds::logic::OFFSET, da
     associatedTypes.insert("mtc");
 }
 
-LogicProcessor::LogicProcessor(int offset, int range, bool doubleStop/*=false*/, bool doubleStart/*=false*/) :
-        EventProcessor(offset, range, "LogicProcessor"), lastStartTime(MAX_LOGIC, NAN), lastStopTime(MAX_LOGIC, NAN),
+LogicProcessor::LogicProcessor(bool doubleStop/*=false*/, bool doubleStart/*=false*/) :
+        EventProcessor(dammIds::logic::OFFSET, dammIds::logic::RANGE, "LogicProcessor"), lastStartTime(MAX_LOGIC, NAN), lastStopTime(MAX_LOGIC, NAN),
         logicStatus(MAX_LOGIC), stopCount(MAX_LOGIC), startCount(MAX_LOGIC) {
     associatedTypes.insert("logic");
     associatedTypes.insert("timeclass"); // old detector type

--- a/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
@@ -117,7 +117,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
     for (auto it = lowDynode.begin(); it != lowDynode.end(); it++) {
         if (DetectorDriver::get()->GetSysRootOutput()) {
             PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd();
+            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
             PSstruct.subtype = (*it)->GetChanID().GetSubtype();
             PSstruct.tag = (*it)->GetChanID().GetGroup();
             pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
@@ -128,7 +128,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
     for (auto it = hiDynode.begin(); it != hiDynode.end(); it++) {
         if (DetectorDriver::get()->GetSysRootOutput()) {
             PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd();
+            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
             PSstruct.subtype = (*it)->GetChanID().GetSubtype();
             PSstruct.tag = (*it)->GetChanID().GetGroup();
             pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
@@ -162,7 +162,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
 
         if (DetectorDriver::get()->GetSysRootOutput()) {
             PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd();
+            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
             PSstruct.subtype = (*it)->GetChanID().GetSubtype();
             PSstruct.tag = (*it)->GetChanID().GetGroup();
             pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
@@ -196,7 +196,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
 
         if (DetectorDriver::get()->GetSysRootOutput()) {
             PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd();
+            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
             PSstruct.subtype = (*it)->GetChanID().GetSubtype();
             PSstruct.tag = (*it)->GetChanID().GetGroup();
             pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
@@ -254,7 +254,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
 
         if (DetectorDriver::get()->GetSysRootOutput()) {
             PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd();
+            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
             PSstruct.subtype = (*it)->GetChanID().GetSubtype();
             PSstruct.tag = (*it)->GetChanID().GetGroup();
             pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
@@ -270,7 +270,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
 
         if (DetectorDriver::get()->GetSysRootOutput()) {
             PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd();
+            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
             PSstruct.subtype = (*it)->GetChanID().GetSubtype();
             PSstruct.tag = (*it)->GetChanID().GetGroup();
             pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
@@ -313,7 +313,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
     for(auto it = separatorScint.begin(); it != separatorScint.end(); it++){
         if (DetectorDriver::get()->GetSysRootOutput()) {
             PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd();
+            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
             PSstruct.subtype = (*it)->GetChanID().GetSubtype();
             PSstruct.tag = (*it)->GetChanID().GetGroup();
             pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
@@ -327,7 +327,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
     for (auto it = desi.begin(); it != desi.end(); it++){
         if (DetectorDriver::get()->GetSysRootOutput()) {
             PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd();
+            PSstruct.time = (*it)->GetTimeSansCfd()* Globals::get()->GetClockInSeconds() * 1e9; //store ns
             PSstruct.subtype = (*it)->GetChanID().GetSubtype();
             PSstruct.tag = (*it)->GetChanID().GetGroup();
             pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);

--- a/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
@@ -385,10 +385,10 @@ pair<double, double> PspmtProcessor::CalculatePosition(double &xa, double &xb, d
 void PspmtProcessor::FillPSPMTStruc(const ChanEvent &chan_event) {
     /** implementation of trace analysis **/
     bool InvalidTrace = false;
-    if (!chan_event.GetTrace().empty()) {
+    if (!chan_event.GetTrace().empty() && chan_event.GetTrace().GetMaxInfo() != make_pair((unsigned)0,(double)0.0)) {
         vector<unsigned> trace = chan_event.GetTrace();
-        unsigned postAvgLen = 20;                                          // number of bins to average at the end of the trace
-        double extremeVariation = 40;                                      // max difference between the min and max values in the baselines
+        unsigned postAvgLen = 20; // number of bins to average at the end of the trace
+        double extremeVariation = 40; // max difference between the min and max values in the baselines
         vector<unsigned> EndTrace(trace.end() - postAvgLen, trace.end());  //trim out the last postAvgLen bins of the trace
 
         // get an iterator from the begining of the trace to the low end of the fit range

--- a/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/PspmtProcessor.cpp
@@ -116,23 +116,13 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
     //Plot Dynode QDCs
     for (auto it = lowDynode.begin(); it != lowDynode.end(); it++) {
         if (DetectorDriver::get()->GetSysRootOutput()) {
-            PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
-            PSstruct.subtype = (*it)->GetChanID().GetSubtype();
-            PSstruct.tag = (*it)->GetChanID().GetGroup();
-            pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
-            PSstruct = processor_struct::PSPMT_DEFAULT_STRUCT;
+            FillPSPMTStruc(*(*it));
         }
         plot(DD_DYNODE_QDC, (*it)->GetTrace().GetQdc(), 0);
     }
     for (auto it = hiDynode.begin(); it != hiDynode.end(); it++) {
         if (DetectorDriver::get()->GetSysRootOutput()) {
-            PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
-            PSstruct.subtype = (*it)->GetChanID().GetSubtype();
-            PSstruct.tag = (*it)->GetChanID().GetGroup();
-            pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
-            PSstruct = processor_struct::PSPMT_DEFAULT_STRUCT;
+            FillPSPMTStruc(*(*it));
         }
         plot(DD_DYNODE_QDC, (*it)->GetTrace().GetQdc(), 1);
     }
@@ -161,12 +151,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
         energy = (*it)->GetCalibratedEnergy();
 
         if (DetectorDriver::get()->GetSysRootOutput()) {
-            PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
-            PSstruct.subtype = (*it)->GetChanID().GetSubtype();
-            PSstruct.tag = (*it)->GetChanID().GetGroup();
-            pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
-            PSstruct = processor_struct::PSPMT_DEFAULT_STRUCT;
+            FillPSPMTStruc(*(*it));
         }
 
         if (energy < threshold_)
@@ -195,12 +180,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
     for (auto it = hiAnode.begin(); it != hiAnode.end(); it++) {
 
         if (DetectorDriver::get()->GetSysRootOutput()) {
-            PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
-            PSstruct.subtype = (*it)->GetChanID().GetSubtype();
-            PSstruct.tag = (*it)->GetChanID().GetGroup();
-            pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
-            PSstruct = processor_struct::PSPMT_DEFAULT_STRUCT;
+            FillPSPMTStruc(*(*it));
         }
 
         //check signals energy vs threshold
@@ -253,12 +233,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
         }
 
         if (DetectorDriver::get()->GetSysRootOutput()) {
-            PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
-            PSstruct.subtype = (*it)->GetChanID().GetSubtype();
-            PSstruct.tag = (*it)->GetChanID().GetGroup();
-            pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
-            PSstruct = processor_struct::PSPMT_DEFAULT_STRUCT;
+            FillPSPMTStruc(*(*it));
         }
     }
 
@@ -269,12 +244,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
         //check signals energy vs threshold
 
         if (DetectorDriver::get()->GetSysRootOutput()) {
-            PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
-            PSstruct.subtype = (*it)->GetChanID().GetSubtype();
-            PSstruct.tag = (*it)->GetChanID().GetGroup();
-            pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
-            PSstruct = processor_struct::PSPMT_DEFAULT_STRUCT;
+            FillPSPMTStruc(*(*it));
         }
         energy = (*it)->GetCalibratedEnergy();
         if (energy < 10)
@@ -312,12 +282,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
 
     for(auto it = separatorScint.begin(); it != separatorScint.end(); it++){
         if (DetectorDriver::get()->GetSysRootOutput()) {
-            PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
-            PSstruct.subtype = (*it)->GetChanID().GetSubtype();
-            PSstruct.tag = (*it)->GetChanID().GetGroup();
-            pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
-            PSstruct = processor_struct::PSPMT_DEFAULT_STRUCT;
+            FillPSPMTStruc(*(*it));
         }
         if ((*it)->GetCalibratedEnergy() > 1 && (*it)->GetCalibratedEnergy() < 10000){
             hasUpstream = true;
@@ -326,12 +291,7 @@ bool PspmtProcessor::PreProcess(RawEvent &event) {
 
     for (auto it = desi.begin(); it != desi.end(); it++){
         if (DetectorDriver::get()->GetSysRootOutput()) {
-            PSstruct.energy = (*it)->GetCalibratedEnergy();
-            PSstruct.time = (*it)->GetTimeSansCfd()* Globals::get()->GetClockInSeconds() * 1e9; //store ns
-            PSstruct.subtype = (*it)->GetChanID().GetSubtype();
-            PSstruct.tag = (*it)->GetChanID().GetGroup();
-            pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
-            PSstruct = processor_struct::PSPMT_DEFAULT_STRUCT;
+            FillPSPMTStruc(*(*it));
         }
         if((*it)->GetCalibratedEnergy() > 1 && (*it)->GetCalibratedEnergy() < 10000){
             hasDeSi = true;
@@ -436,4 +396,57 @@ pair<double, double> PspmtProcessor::CalculatePosition(double &xa, double &xb, d
     x = (x_tmp - center) * cos(rot) - (y_tmp - center) * sin(rot) + center;  //rotate positions about center of image by angle rot    
     y = (x_tmp - center) * sin(rot) + (y_tmp - center) * cos(rot) + center;
     return make_pair(x, y);
+}
+
+void PspmtProcessor::FillPSPMTStruc(const ChanEvent &chan_event){
+
+    /** implementation of trace analysis **/
+    Double_t energy = 0;
+    if(chan_event.GetTrace().size()){
+        const std::vector<unsigned int> tr = chan_event.GetTrace();
+        if(tr.size()>129){
+            /* subtract baseline */
+            const Int_t kNBins = 40;
+            Double_t baseline = 0;
+            for(int i=0; i<kNBins; ++i){
+                baseline += tr.at(i);
+            }
+            baseline = baseline/(double)kNBins;
+            /* baseline at later time */
+            Double_t baseline_later = 0;
+            for(int i=110; i<130; ++i){
+                baseline_later += tr.at(i);
+            }
+            baseline_later = baseline_later/20.;
+
+            auto itr = std::max_element(tr.begin(),tr.end());
+            energy = (*itr);
+            /* bad trace rejection */
+            for(int i=0; i<kNBins; ++i){
+                if(abs(tr.at(i)-baseline > 40)){
+                    energy = 0;
+                    break;
+                }
+            }
+            const int distance = std::distance(tr.begin(),itr);
+            if(distance>70||distance<40)
+                energy = 0;
+            if(abs(baseline - baseline_later)>400 &&
+                chan_event.GetChanID().GetSubtype()=="dynode_high")
+                energy = 0;
+        }
+    }
+    else{
+        energy = chan_event.GetCalibratedEnergy();
+    }
+
+    /* fills PSstruct members */
+    PSstruct.energy = energy;
+    PSstruct.time = chan_event.GetTimeSansCfd() * Globals::get()->GetClockInSeconds() * 1e9; //store ns
+    PSstruct.subtype = chan_event.GetChanID().GetSubtype();
+    PSstruct.tag = chan_event.GetChanID().GetGroup();
+    pixie_tree_event_->pspmt_vec_.emplace_back(PSstruct);
+    PSstruct = processor_struct::PSPMT_DEFAULT_STRUCT;
+
+    return;
 }

--- a/Analysis/Utkscan/processors/source/RootDevProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/RootDevProcessor.cpp
@@ -1,0 +1,70 @@
+/** @file RootDevProcessor.cpp
+ *  @brief Basic ROOT output. Fills a generic struc in the same tree layout as the other processors. It has NO damm output
+ *  @authors T.T. King
+ *  @date 03/30/2019
+*/
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+#include "DetectorDriver.hpp"
+#include "DetectorLibrary.hpp"
+#include "HelperFunctions.hpp"
+#include "RawEvent.hpp"
+#include "RootDevProcessor.hpp"
+
+using namespace std;
+
+RootDevProcessor::RootDevProcessor() : EventProcessor() {
+    associatedTypes.insert("RD");
+}
+
+bool RootDevProcessor::PreProcess(RawEvent &event) {
+    if (!EventProcessor::PreProcess(event))
+        return false;
+
+    return true;
+}
+
+bool RootDevProcessor::Process(RawEvent &event) {
+    if (!EventProcessor::Process(event))
+        return false;
+
+    //vector <ChanEvent*>
+    static const auto &Events = event.GetSummary("RD", true)->GetList();
+
+    for (auto it = Events.begin(); it != Events.end(); it++) {
+        RDstruct.energy = (*it)->GetCalibratedEnergy();
+        RDstruct.rawEnergy = (*it)->GetEnergy();
+        RDstruct.timeSansCfd = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds();
+        RDstruct.time = (*it)->GetTime() * Globals::get()->GetAdcClockInSeconds();
+        RDstruct.detNum = (*it)->GetChanID().GetLocation();
+        RDstruct.modNum = (*it)->GetModuleNumber();
+        RDstruct.chanNum = (*it)->GetChannelNumber();
+        RDstruct.subtype = (*it)->GetChanID().GetSubtype();
+        RDstruct.group = (*it)->GetChanID().GetGroup();
+        RDstruct.pileup = (*it)->IsPileup();
+        RDstruct.saturation = (*it)->IsSaturated();
+
+        if ((*it)->GetTrace().size() > 0) {
+            RDstruct.trace = (*it)->GetTrace();
+            RDstruct.maxPos = (*it)->GetTrace().GetMaxInfo().first;
+            RDstruct.maxVal = (*it)->GetTrace().GetMaxInfo().second;
+            RDstruct.tqdc = (*it)->GetTrace().GetQdc();
+            RDstruct.highResTime = (*it)->GetHighResTimeInNs();
+        }
+        if (!(*it)->GetQdc().empty()) {
+            RDstruct.qdcSums = (*it)->GetQdc();
+        }
+        pixie_tree_event_->root_dev_vec_.emplace_back(RDstruct);
+        RDstruct = processor_struct::ROOTDEV_DEFAULT_STRUCT;
+    }
+
+    EndProcess();
+    return true;
+}

--- a/Analysis/Utkscan/processors/source/RootDevProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/RootDevProcessor.cpp
@@ -41,8 +41,8 @@ bool RootDevProcessor::Process(RawEvent &event) {
     for (auto it = Events.begin(); it != Events.end(); it++) {
         RDstruct.energy = (*it)->GetCalibratedEnergy();
         RDstruct.rawEnergy = (*it)->GetEnergy();
-        RDstruct.timeSansCfd = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds();
-        RDstruct.time = (*it)->GetTime() * Globals::get()->GetAdcClockInSeconds();
+        RDstruct.timeSansCfd = (*it)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds((*it)->GetChanID().GetModFreq());
+        RDstruct.time = (*it)->GetTime() * Globals::get()->GetAdcClockInSeconds((*it)->GetChanID().GetModFreq());
         RDstruct.detNum = (*it)->GetChanID().GetLocation();
         RDstruct.modNum = (*it)->GetModuleNumber();
         RDstruct.chanNum = (*it)->GetChannelNumber();

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -87,7 +87,7 @@ void VandleProcessor::DeclarePlots(void) {
 
         DeclareHistogram2D(DD_TIMEDIFFBARS + offset.second, SB, S6, "UNCALIBRATED: Bars vs. Time Differences (0.5ns/bin)");
         DeclareHistogram2D(DD_TOFBARS + offset.second, SC, S8, "UNCALIBRATED: Bar vs. Time of Flight (0.5ns/bin)");
-        DeclareHistogram2D(DD_TQDCAVEVSTOF+ offset.second, SC, S8, "UNCALIBRATED: <E> vs. TOF (0.5ns/bin)");
+        DeclareHistogram2D(DD_TQDCAVEVSTOF+ offset.second, SC, SD, "UNCALIBRATED: <E> vs. TOF (0.5ns/bin)");
 
         DeclareHistogram2D(DD_QDCTOF_DECAY+offset.first,SC,SD, "<E> vs. TOF (0.5ns/bin) Rough Decay Gated ");
         DeclareHistogram2D(DD_TOFBARS_DECAY+offset.first,SC,S6, "Bar vs. TOF (0.5ns/bin) Rough Decay Gated ");

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,11 @@ option(PAASS_BUILD_TESTS "Builds programs designed to test the package. Includin
 option(PAASS_BUILD_UTKSCAN "Build utkscan" OFF)
 option(PAASS_USE_DAMM "Use DAMM for MCA" ON)
 option(PAASS_USE_NCURSES "Use ncurses for terminal" ON)
-mark_as_advanced(PAASS_USE_NCURSES)
 option(PAASS_USE_ROOT "Use ROOT" ON)
+
+mark_as_advanced(PAASS_USE_NCURSES)
+mark_as_advanced(PAASS_USE_DAMM)
+mark_as_advanced(PAASS_USE_ROOT)
 
 option(PAASS_EXPORT_COMPILE_COMMANDS "CMAKE_EXPORT_COMPILE_COMMANDS WRAPPER" ON)
 mark_as_advanced(PAASS_EXPORT_COMPILE_COMMANDS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,18 @@ option(PAASS_USE_NCURSES "Use ncurses for terminal" ON)
 mark_as_advanced(PAASS_USE_NCURSES)
 option(PAASS_USE_ROOT "Use ROOT" ON)
 
+option(PAASS_EXPORT_COMPILE_COMMANDS "CMAKE_EXPORT_COMPILE_COMMANDS WRAPPER" ON)
+mark_as_advanced(PAASS_EXPORT_COMPILE_COMMANDS)
+
+#Generate the compile_commands.json file which is used by VSCode (among others) to generate the clang autocomplete
+#Needs the PAASS_EXPORT_COMPILE_COMMANDS wrapper because of the "FORCE" which is required to even set the var from CMakeList.txt,
+#while maintaining the ability to toggle it on/off without wiping the build dir
+if(PAASS_EXPORT_COMPILE_COMMANDS)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "Generates compile_commands.json, needed for some IDEs among other things" FORCE)
+else ()
+    set(CMAKE_EXPORT_COMPILE_COMMANDS OFF CACHE BOOL "Generates compile_commands.json, needed for some IDEs among other things" FORCE)   
+endif (PAASS_EXPORT_COMPILE_COMMANDS)
+
 #------------------------------------------------------------------------------
 
 #Definitions with compiler options

--- a/Cmake/modules/FindROOT.cmake
+++ b/Cmake/modules/FindROOT.cmake
@@ -11,7 +11,7 @@
 #Last updated by S. V. Paulauskas (stanpaulauskas AT gmail DOT com) on May 27, 2017
 
 #Find the root-config executable
-set(ROOTSYS $ENV{ROOTSYS} CACHE Path "ROOT directory.")
+set(ROOTSYS $ENV{ROOTSYS} CACHE STRING "ROOT directory.")
 find_program(ROOT_CONFIG_EXECUTABLE root-config
         PATHS ${ROOTSYS}/bin)
 find_program(ROOTCINT_EXECUTABLE rootcint PATHS $ENV{ROOTSYS}/bin)

--- a/Resources/include/HelperEnumerations.hpp
+++ b/Resources/include/HelperEnumerations.hpp
@@ -25,7 +25,7 @@ namespace DataProcessing {
     /// * R27361 is valid from 06/11/2013 to 02/15/2014
     /// * R29432 is valid from 02/15/2014 to 07/28/2014
     /// * R30474, R30980, R30981 is valid from 07/28/2014 to 03/08/2016
-    /// * R29432 is valid from 03/08/2016
+    /// * R34688 is valid from 03/08/2016
     /// * UNKNOWN is used for unspecified firmware revisions.
     ///These dates do not imply that the particular data set being analyzed was
     /// taken with the expected firmware. These dates are meant only to help

--- a/Resources/include/HelperFunctions.hpp
+++ b/Resources/include/HelperFunctions.hpp
@@ -207,7 +207,7 @@ namespace Statistics {
 
 namespace TraceFunctions {
     ///The minimum length that is necessary for a good baseline calculation.
-    static const unsigned int minimum_baseline_length = 10;
+    static const int minimum_baseline_length = 10;
 
     ///@brief Compute the trace baseline and its standard deviation. This
     /// function takes a data range in the event that someone wants to


### PR DESCRIPTION
Lots of upgrades and bug fixes. 

Most important changes are (in no particular order) : 
1) GetTime() changed to ALWAYS return ADC clock ticks and GetTimeSansCFD() always returns DSP clock ticks. 
     - Meaning that the conversion for GetTime() is ALWAY GetAdcClockInSeconds() and GetTimeSansCfd() is ALWAYS either GetClockInSeconds() or GetFilterClockInSeconds()

2) VANDLE
      - Geometry corrected Time of Flight (corTof) for VANDLE now corrects all bars to a single distance.
      -  Fixed the SpeedOfLightIn...Bar constants to always be set. Because this is set by the GlobalsXmlParser.cpp the easy way is to just always set them, because we cant depend on the Map or the DetectorDriver nodes being parsed already. We retain the ability to override them in this node (any combination of them)

3) Multi Crate related:
      - New overloads for GetClockInSeconds(), GetAdcClock..., GetFilterClock... that take the module frequency as input to return the correct tick -> second conversion factor. (Only available with Rev F set in the <Global> node of the xml)
      - Added module frequency to the ChanID class.

4) New processor for detector development and testing (RootDevProcessor). This processor tries to dump as much of the information from the ChanEvent as possible. 

      - Raw Energy
      - Calibrated Energy
      - Evt Time Sans Cfd in ns
      - Evt Time in ns
      - Location in the map
      - Module number
      - Channel number 
      - Subtype 
      - Group
      - Pileup (from pixie)
      - Saturation (from pixie)
      - Trace (if present)
      - Position of the Max (if we have a trace)
      - Value of the Max (if we have a trace)
      - Trace QDC (if we have a trace)
      - High Res Time in ns (if we have a trace)
      - The onboard QDC sums if present in the list mode

5) Added initial support for the new R42159 firmware with its new CCSRA bits 

6) Added some trace based analysis to the PspmtProcessor, to reject events with traces which are obviously bad, reflections, induced signals from ion implantation in the high gain channels, etc. These tests require the Waveform Analyzer but not the Fitting Analyzer. The Waveform Analyzer ignore list works like before, but the Fitting Analyzer's lets the Waveform Analyzer do its thing then stop before starting the fit.

7) Marked some of the cmake options that we don't use as Advanced to clear up the ccmake output