### PR TITLE
Pull in the updates from the mix_bit_upgrades branch

### DIFF
--- a/Acquisition/Poll/include/poll2_core.h
+++ b/Acquisition/Poll/include/poll2_core.h
@@ -247,6 +247,13 @@ private:
     /// @return Whether the attempt was succesful.
     bool SplitParameterArgs(const std::string &arg, int &start, int &stop);
 
+    /// @breif Checks is the entered module is actually installed in the system. 
+    /// The Pixie API handles the reads and the channels but does not have a check that a given module is actually installed in the crate. If not then poll2 will hang and need to be hard killed. 
+    /// Because we always run sequentially; this is a less than check against the num of booted cards
+    /// @param[in] Module number from command line
+    /// @return true is module is installed.
+    bool IsValidModule(const int &modNum);
+
 public:
     /// Default constructor.
     Poll();

--- a/Acquisition/Poll/source/poll2_core.cpp
+++ b/Acquisition/Poll/source/poll2_core.cpp
@@ -1331,7 +1331,8 @@ void Poll::CommandControl(){
                     continue;
                 }
 
-                bool IsValidNumber = (arguments.at(2).find_first_not_of("0123456789") == std::string::npos);
+                bool IsValidNumber = IsNumeric(arguments.at(2));
+
                 if (IsValidNumber && atoi(arguments.at(2).c_str()) >= 24) {
                     std::cout << "ERROR: Invalid CCSRA bit number: '" << arguments.at(2) << "'\n";
                     continue;

--- a/Acquisition/Poll/source/poll2_core.cpp
+++ b/Acquisition/Poll/source/poll2_core.cpp
@@ -1295,18 +1295,30 @@ void Poll::CommandControl(){
                     std::cout << "ERROR: Invalid channel argument: '" << arguments.at(1) << "'\n";
                     continue;
                 }
-                flipper.SetCSRAbit(arguments.at(2));
 
-                std::string dum_str = "CHANNEL_CSRA";
-                bool error = false;
-                for (int mod = modStart; mod <= modStop; mod++) {
-                    for (int ch = chStart; ch <= chStop; ch++) {
-                        if(!forChannel(pif, mod, ch, flipper, dum_str)){
-                            error = true;
-                        }
+                bool IsValidNumber = (arguments.at(2).find_first_not_of("0123456789") == std::string::npos);
+                if (IsValidNumber && atoi(arguments.at(2).c_str()) >= 24) {
+                    std::cout << "ERROR: Invalid CCSRA bit number: '" << arguments.at(2) << "'\n";
+                    continue;
+                } else if (!IsValidNumber) {
+                    if (std::find(BitFlipper::toggle_names.begin(), BitFlipper::toggle_names.end(), arguments.at(2)) == BitFlipper::toggle_names.end()) {
+                        std::cout << "ERROR: Invalid toggle name: '" << arguments.at(2) << "'\n";
+                        continue;
                     }
                 }
-                if (!error) pif->SaveDSPParameters();
+
+                    flipper.SetCSRAbit(arguments.at(2));
+
+                    std::string dum_str = "CHANNEL_CSRA";
+                    bool error = false;
+                    for (int mod = modStart; mod <= modStop; mod++) {
+                        for (int ch = chStart; ch <= chStop; ch++) {
+                            if (!forChannel(pif, mod, ch, flipper, dum_str)) {
+                                error = true;
+                            }
+                        }
+                    }
+                    if (!error) pif->SaveDSPParameters();
             }
             else{
                 std::cout << sys_message_head << "Invalid number of parameters to toggle\n";

--- a/Acquisition/Poll/source/poll2_core.cpp
+++ b/Acquisition/Poll/source/poll2_core.cpp
@@ -961,7 +961,8 @@ void Poll::CommandControl(){
                 cmd = "stop";
             }
             else {
-                std::cout << " Ignoring signal.\n";
+                std::cout << " Clearing Cmd Line\n";
+                poll_term_->ClearCmd();
                 continue;
             }
         }

--- a/Acquisition/Poll/source/poll2_core.cpp
+++ b/Acquisition/Poll/source/poll2_core.cpp
@@ -648,19 +648,19 @@ void Poll::help(){
         std::cout << "   reboot              - Reboot PIXIE crate\n";
         std::cout << "   stats [time]        - Set the time delay between statistics dumps (default=-1)\n";
     }
-    std::cout << "   mca [root|damm] [time] [filename]     - Use MCA to record data for debugging purposes\n";
-    std::cout << "   dump [filename]                       - Dump pixie settings to file (default='Fallback.set')\n";
+    std::cout << "   mca [damm|root] [time] [filename]     - Use MCA to record data for debugging purposes\n";
     std::cout << "   pread <mod> <chan> <param>            - Read parameters from individual PIXIE channels\n";
     std::cout << "   pmread <mod> <param>                  - Read parameters from PIXIE modules\n";
     std::cout << "   pwrite <mod> <chan> <param> <val>     - Write parameters to individual PIXIE channels\n";
     std::cout << "   pmwrite <mod> <param> <val>           - Write parameters to PIXIE modules\n";
     std::cout << "   adjust_offsets <module>               - Adjusts the baselines of a pixie module\n";
-    std::cout << "   find_tau <module> <channel>           - Finds the decay constant for an active pixie channel\n";
-    std::cout << "   toggle <module> <channel> <bit>       - Toggle any of the 22 CHANNEL_CSRA bits for a pixie channel\n";
+    std::cout << "   toggle <module> <channel> <bit>       - Toggle any of the 24 CHANNEL_CSRA bits for a pixie channel\n";
     std::cout << "   toggle_bit <mod> <chan> <param> <bit> - Toggle any bit of any parameter of 32 bits or less\n";
     std::cout << "   csr_test <number>                     - Output the CSRA parameters for a given integer\n";
     std::cout << "   bit_test <num_bits> <number>          - Display active bits in a given integer up to 32 bits long\n";
+    std::cout << "   dump [filename]                       - Dump pixie settings to file (default='Param_Dump.txt')\n";
     std::cout << "   save [setFilename]                    - Writes the DSP Parameters to [setFileName] (default='active .set from pixie_cfg')\n";
+     std::cout << "   find_tau <module> <channel>           - Finds the decay constant for an active pixie channel\n";
     std::cout << "   get_traces <mod> <chan> [threshold]   - Get traces for all channels in a specified module\n";
     std::cout << "   status              - Display system status information\n";
     std::cout << "   thresh [threshold]  - Modify or display the current polling threshold.\n";
@@ -1040,9 +1040,9 @@ void Poll::CommandControl(){
                 }
             }
             else{
-                ofile.open("./Fallback.set");
+                ofile.open("./Param_Dump.txt");
                 if(!ofile.good()){
-                    std::cout << sys_message_head << "Failed to open output file './Fallback.set'\n";
+                    std::cout << sys_message_head << "Failed to open output file './Param_Dump.txt'\n";
                     continue;
                 }
             }
@@ -1175,7 +1175,7 @@ void Poll::CommandControl(){
             }
             else {
                 std::cout << sys_message_head << "Invalid number of parameters to save\n";
-                std::cout << sys_message_head << " -SYNTAX- save [setFilename]\n";
+                std::cout << sys_message_head << " -SYNTAX- save [setFilename].set\n";
                 continue;
             }
         }

--- a/Acquisition/Poll/source/poll2_core.cpp
+++ b/Acquisition/Poll/source/poll2_core.cpp
@@ -865,6 +865,16 @@ bool Poll::SplitParameterArgs(const std::string &arg, int &start, int &stop) {
     }
     return true;
 }
+
+/// This method checks that the entered module is actually installed in the crate.
+bool Poll::IsValidModule(const int &modNum){
+    if (modNum > (int)n_cards - 1 ) {
+        std::cout << "ERROR: Invalid module: '" << modNum << "'\n";
+        return false;
+    } else {
+        return true;
+    }
+}
 ///////////////////////////////////////////////////////////////////////////////
 // Poll::CommandControl
 ///////////////////////////////////////////////////////////////////////////////
@@ -1079,6 +1089,9 @@ void Poll::CommandControl(){
                         std::cout << "ERROR: Invalid module argument: '" << arguments.at(0) << "'\n";
                         continue;
                     }
+                    if (!IsValidModule(modStart) || !IsValidModule(modStop) ){
+                        continue;
+                    }
                     int chStart, chStop;
                     if (!SplitParameterArgs(arguments.at(1), chStart, chStop)) {
                         std::cout << "ERROR: Invalid channel argument: '" << arguments.at(1) << "'\n";
@@ -1126,6 +1139,10 @@ void Poll::CommandControl(){
                         continue;
                     }
 
+                    if (!IsValidModule(modStart) || !IsValidModule(modStop) ){
+                        continue;
+                    }
+                    
                     //Check that there are no characters in the string unless it is hex.
                     std::string &valueStr = arguments.at(2);
                     if (valueStr.find_last_not_of("0123456789") != std::string::npos &&
@@ -1200,6 +1217,10 @@ void Poll::CommandControl(){
                         continue;
                     }
 
+                    if (!IsValidModule(modStart) || !IsValidModule(modStop)) {
+                        continue;
+                    }
+
                     ParameterChannelReader reader;
                     for (int mod = modStart; mod <= modStop; mod++) {
                         for (int ch = chStart; ch <= chStop; ch++) {
@@ -1218,6 +1239,10 @@ void Poll::CommandControl(){
                     int modStart, modStop;
                     if (!SplitParameterArgs(arguments.at(0), modStart, modStop)) {
                         std::cout << "ERROR: Invalid module argument: '" << arguments.at(0) << "'\n";
+                        continue;
+                    }
+
+                    if (!IsValidModule(modStart) || !IsValidModule(modStop)) {
                         continue;
                     }
 
@@ -1242,6 +1267,10 @@ void Poll::CommandControl(){
                 int modStart, modStop;
                 if (!SplitParameterArgs(arguments.at(0), modStart, modStop)) {
                     std::cout << "ERROR: Invalid module argument: '" << arguments.at(0) << "'\n";
+                    continue;
+                }
+
+                if (!IsValidModule(modStart) || !IsValidModule(modStop) ) {
                     continue;
                 }
 
@@ -1291,6 +1320,11 @@ void Poll::CommandControl(){
                     std::cout << "ERROR: Invalid module argument: '" << arguments.at(0) << "'\n";
                     continue;
                 }
+
+                if (!IsValidModule(modStart) || !IsValidModule(modStop)  ) {
+                    continue;
+                }
+
                 int chStart, chStop;
                 if (!SplitParameterArgs(arguments.at(1), chStart, chStop)) {
                     std::cout << "ERROR: Invalid channel argument: '" << arguments.at(1) << "'\n";
@@ -1335,10 +1369,15 @@ void Poll::CommandControl(){
 
             BitFlipper flipper;
 
-            if(p_args >= 4){
-                if(!IsNumeric(arguments.at(0), sys_message_head, "Invalid module specification")) continue;
-                else if(!IsNumeric(arguments.at(1), sys_message_head, "Invalid channel specification")) continue;
-                else if(!IsNumeric(arguments.at(3), sys_message_head, "Invalid bit number specification")) continue;
+            if (p_args >= 4) {
+                if (!IsNumeric(arguments.at(0), sys_message_head, "Invalid module specification") ||
+                    !IsValidModule(atoi(arguments.at(0).c_str()))) {
+                    continue;
+                } else if (!IsNumeric(arguments.at(1), sys_message_head, "Invalid channel specification")) {
+                    continue;
+                } else if (!IsNumeric(arguments.at(3), sys_message_head, "Invalid bit number specification")) {
+                    continue;
+                }
                 flipper.SetBit(arguments.at(3));
 
                 if(forChannel(pif, atoi(arguments.at(0).c_str()), atoi(arguments.at(1).c_str()), flipper, arguments.at(2))){

--- a/Analysis/Resources/include/DefaultConfigurationValues.hpp
+++ b/Analysis/Resources/include/DefaultConfigurationValues.hpp
@@ -24,7 +24,7 @@ namespace DefaultConfig {
     static const double fitGamma = 0.208072;
 
     ///These are used when reading /Configuration/Map/Module/Channel/Cfd
-    static const double cfdF = 0.8;
+    static const double cfdF = 0.45;
     static const double cfdD = 1.;
     static const double cfdL = 0.;
 }

--- a/Analysis/Resources/include/PolynomialCfd.hpp
+++ b/Analysis/Resources/include/PolynomialCfd.hpp
@@ -5,11 +5,16 @@
 #ifndef PIXIESUITE_POLYNOMIALCFD_HPP
 #define PIXIESUITE_POLYNOMIALCFD_HPP
 
+#include "Exceptions.hpp"
 #include "TimingDriver.hpp"
 
 class PolynomialCfd : public TimingDriver {
 public:
-    PolynomialCfd() {};
+    /// Default constructor 
+    PolynomialCfd();
+
+    ///Constructor taking poly method 1 or 2 as input
+    PolynomialCfd(const int &method);
 
     ~PolynomialCfd() {};
 
@@ -18,6 +23,16 @@ public:
                           const std::pair<double, double> &pars,
                           const std::pair<unsigned int, double> &max,
                           const std::pair<double, double> baseline);
+
+private:
+ /// Calculates the phase using a 2nd order polynomial around the threshold
+ double CalcPoly2Phase(const double &thresh, const double &traceMax_, const std::vector<double> &data);
+
+ /// Calculates the phase using a 1st order polynomial (linear) around the threshold
+ double CalcPoly1Phase(const double &thresh, const double &traceMax_, const std::vector<double> &data);
+
+ /// order of the polynomial to use around the threshold
+ int polyMethod_;
 };
 
 #endif //PIXIESUITE_POLYNOMIALCFD_HPP

--- a/Analysis/Resources/source/PolynomialCfd.cpp
+++ b/Analysis/Resources/source/PolynomialCfd.cpp
@@ -10,24 +10,67 @@
 
 using namespace std;
 
+PolynomialCfd::PolynomialCfd(){
+    polyMethod_ = 1;
+}
+
+PolynomialCfd::PolynomialCfd(const int &method){
+    
+    switch ( method ) {
+        case 1:
+        case 2:
+            polyMethod_ = method;
+            break;
+        default:
+            throw GeneralException("PolynomialCfd::Unsupported Interpolation method!");       
+    }
+    
+}
+
+
 /// Perform CFD analysis on the waveform.
-double PolynomialCfd::CalculatePhase(const std::vector<double> &data, const std::pair<double, double> &pars,
-                                     const std::pair<unsigned int, double> &max,
-                                     const std::pair<double, double> baseline) {
+double PolynomialCfd::CalculatePhase(const std::vector<double> &data, const std::pair<double, double> &pars,const std::pair<unsigned int, double> &max, const std::pair<double, double> baseline) {
     if (data.size() == 0)
         throw range_error("PolynomialCfd::CalculatePhase - The data vector was empty!");
     if (data.size() < max.first)
-        throw range_error("PolynomialCfd::CalculatePhase - The maximum "
-                                  "position is larger than the size of the "
-                                  "data vector.");
+        throw range_error("PolynomialCfd::CalculatePhase - The maximum position is larger than the size of the data vector.");
 
     double threshold = pars.first * max.second;
     double phase = -9999;
+  
+    if (polyMethod_ == 1) {
+        phase = CalcPoly1Phase(threshold,max.first,data);
+        //  cout<< "PolyCFD_method=: "<<polyMethod_<<"   Returned "<< phase << " as the phase      threshold(%) = "<< threshold << " (" << pars.first << ")" <<endl;
+    } else if (polyMethod_ == 2){
+        phase = CalcPoly2Phase(threshold,max.first,data);
+    }
+    
+    return phase;
+}
+
+double PolynomialCfd::CalcPoly1Phase(const double &thresh, const double &traceMax_, const std::vector<double> &data) {
+    double pol1Phase_ = -9999;
+
+    vector<double> result;
+    for (unsigned int cfdIndex = traceMax_; cfdIndex > 0; cfdIndex--) {
+        if (data[cfdIndex - 1] < thresh && data[cfdIndex] >= thresh) {
+            // Fit the rise of the trace to a 2nd order polynomial.
+            result = Polynomial::CalculatePoly1(data, cfdIndex - 1).second;
+
+            pol1Phase_ = (thresh - result[0]) / result[1];
+            break;
+        }
+    }
+    return pol1Phase_;
+}
+
+double PolynomialCfd::CalcPoly2Phase(const double &thresh, const double &traceMax_, const std::vector<double> &data){
+    double pol2Phase_=-9999;
     float multiplier = 1.;
 
     vector<double> result;
-    for (unsigned int cfdIndex = max.first; cfdIndex > 0; cfdIndex--) {
-        if (data[cfdIndex - 1] < threshold && data[cfdIndex] >= threshold) {
+    for (unsigned int cfdIndex = traceMax_; cfdIndex > 0; cfdIndex--) {
+        if (data[cfdIndex - 1] < thresh && data[cfdIndex] >= thresh) {
             // Fit the rise of the trace to a 2nd order polynomial.
             result = Polynomial::CalculatePoly2(data, cfdIndex - 1).second;
 
@@ -35,11 +78,10 @@ double PolynomialCfd::CalculatePhase(const std::vector<double> &data, const std:
             if (result[2] > 1)
                 multiplier = -1.;
 
-            phase = (-result[1] + multiplier * sqrt(result[1] * result[1] - 4 * result[2] * (result[0] - threshold)))
-                    / (2 * result[2]);
+            pol2Phase_ = (-result[1] + multiplier * sqrt(result[1] * result[1] - 4 * result[2] * (result[0] - thresh))) / (2 * result[2]);
 
             break;
         }
     }
-    return phase;
+    return pol2Phase_;
 }

--- a/Analysis/ScanLibraries/include/Trace.hpp
+++ b/Analysis/ScanLibraries/include/Trace.hpp
@@ -96,11 +96,11 @@ public:
         return std::vector<unsigned int>(begin() + waveformRange_.first, begin() + waveformRange_.second);
     }
     
-    ///@return True if the Waveform Analysis was completed sucessfully, this is a legacy carryover. Please use HasValidWaveformAnalysis().  
+    ///@return True if the Waveform Analysis was completed successfully, this is a legacy carryover. Please use HasValidWaveformAnalysis().  
     bool HasValidAnalysis() const {return hasValidWaveformAnalysis_; }
 
     ///@return True if the fit of the trace was completed.
-    bool HasValidFitAnalysis() const { return hasValidFitAnalysis_; }
+    bool HasValidTimingAnalysis() const { return hasValidTimingAnalysis_; }
 
     ///@return True if we were able to successfully analyze the trace.
     bool HasValidWaveformAnalysis() const { return hasValidWaveformAnalysis_; }
@@ -136,7 +136,7 @@ public:
     ///Sets the value of hasValidWaveformAnalysis_
     ///@param[in] a : True if we were able to successfully fit this trace
     /// for information about the maximum, baseline, phase, etc.
-    void SetHasValidFitAnalysis(const bool &a) { hasValidFitAnalysis_ = a; }
+    void SetHasValidTimingAnalysis(const bool &a) { hasValidTimingAnalysis_ = a; }
 
     ///Sets the value of hasValidWaveformAnalysis_
     ///@param[in] a : True if we were able to successfully analyze this waveform
@@ -194,7 +194,7 @@ public:
 private:
     bool isSaturated_; ///< True if the trace was flagged as saturated.
     bool hasValidWaveformAnalysis_;///< True if the analysis of the waveform was successful (no fitting)
-    bool hasValidFitAnalysis_;///< True if the fit of the trace was completed
+    bool hasValidTimingAnalysis_;///< True if the fit/cfd of the trace was completed
 
     double phase_; ///< The sub-sampling phase of the trace.
     double qdc_; ///< The qdc that was calculated from the waveform.

--- a/Analysis/ScanLibraries/source/Unpacker.cpp
+++ b/Analysis/ScanLibraries/source/Unpacker.cpp
@@ -231,7 +231,7 @@ void Unpacker::InitializeDataMask(const std::string &firmware, const unsigned in
     if (frequency == 0) {
         unsigned int modCounter = 0;
         pugi::xml_node node = XmlInterface::get(firmware)->GetDocument()->child("Configuration").child("Map");
-        unsigned int globalFreq_ = node.attribute("frequency").as_uint();
+        unsigned int globalFreq_ = node.attribute("frequency").as_uint(0);
         string globalFirm_ = node.attribute("firmware").as_string();
 
         for (pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it, modCounter++) {

--- a/Analysis/ScanLibraries/source/XiaListModeDataDecoder.cpp
+++ b/Analysis/ScanLibraries/source/XiaListModeDataDecoder.cpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <bitset>
 
+#include <stdlib.h>
 #include <cmath>
 
 #include "HelperEnumerations.hpp"
@@ -150,6 +151,25 @@ vector<XiaData *> XiaListModeDataDecoder::DecodeBuffer(unsigned int *buf, const 
           //   printf("SetExternalTimeHigh %u \n", buf[5]);
           // }
 
+        //   printf("\n");
+        //   printf("header length (1 counting) = %u \n", headerLength);
+        //   printf("ETS Word1 (Last Buf Word - 1;ETS_low) = %u \n", buf[headerLength - 2]);
+        //   cout << "ETS Word1 Binary= " << std::bitset<32>(buf[headerLength - 2]) << endl
+        //        << endl;
+
+        //   if (data->GetExternalTimeLow() > 4000000000) {
+        //       cout << "Approching UInt max" << endl
+        //            << endl;
+        //   }
+
+        //   printf("ETS Word2 (Last Buf Word; CCI_ETS_HIGH)=                    %u \n", buf[headerLength - 1]);
+        //   cout << "ETS Word2 Binary= " << std::bitset<32>(buf[headerLength - 1]) << endl<<endl;
+
+        //   printf("Header Word4 (Trace ORF, Trace Len, EVT En)= %u \n", buf[headerLength - 3]);
+        //   cout << "Header Word4 Binary= " << std::bitset<32>(buf[headerLength - 3]) << endl;
+
+        //   printf("\n");
+
           data->SetExternalTimeStamp(CalculateExternalTimeStamp(*data));
           if(headerLength);
           // printf("headerLength %u, ", headerLength);
@@ -169,10 +189,10 @@ vector<XiaData *> XiaListModeDataDecoder::DecodeBuffer(unsigned int *buf, const 
         //channel_counts[modNum][chanNum]++;
 
         ///@TODO This needs to be revised to take into account the bit
-        /// resolution of the modules. I've currently set it to the maximum
+        /// resolution of the modules. I've currently set it to 10 more than maximum
         /// bit resolution of any module (16-bit).
         if (data->IsSaturated())
-            data->SetEnergy(65536);
+            data->SetEnergy(65546);
 
         //We set the time according to the revision and firmware.
         pair<double, double> times = CalculateTimeInSamples(mask, *data);

--- a/Analysis/ScanLibraries/source/XiaListModeDataMask.cpp
+++ b/Analysis/ScanLibraries/source/XiaListModeDataMask.cpp
@@ -19,9 +19,9 @@ FIRMWARE XiaListModeDataMask::ConvertStringToFirmware(const std::string &type) {
     //First convert the string into a number
     if (type.find("R") == 0 || type.find("r") == 0) {
         string tmp(type.begin() + 1, type.end());
-        firmwareNumber = (unsigned int) atoi(tmp.c_str());
+        firmwareNumber = (unsigned int)atoi(tmp.c_str());
     } else
-        firmwareNumber = (unsigned int) atoi(type.c_str());
+        firmwareNumber = (unsigned int)atoi(type.c_str());
 
     if (firmwareNumber >= 17562 && firmwareNumber < 20466)
         firmware = R17562;
@@ -37,10 +37,12 @@ FIRMWARE XiaListModeDataMask::ConvertStringToFirmware(const std::string &type) {
         firmware = R30980;
     else if (firmwareNumber >= 30981 && firmwareNumber < 34688)
         firmware = R30981;
-    else if (firmwareNumber == 34688) //compare exactly here since nothing higher
+    else if (firmwareNumber == 35207)  //14b 500MHz RevF
+        firmware = R35207; //TODO we are hard matching this one because we are unsure of its structure. once we have some time we should see if its any different than the 34688->42950 structure (it shouldnt be)
+    else if (firmwareNumber >= 34688 && firmwareNumber <= 42950)  //42950 is is the newest 16b:250 firmware, received at the end of August 2019
         firmware = R34688;
     else {
-        msg << "XiaListModeDataMask::CovnertStringToFirmware : "
+        msg << "XiaListModeDataMask::ConvertStringToFirmware : "
             << "Unrecognized firmware option - " << type << endl;
         throw invalid_argument(msg.str());
     }
@@ -52,8 +54,7 @@ FIRMWARE XiaListModeDataMask::ConvertStringToFirmware(const std::string &type) {
 pair<unsigned int, unsigned int>
 XiaListModeDataMask::GetCfdFractionalTimeMask() const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
-        throw invalid_argument(BadMaskErrorMessage
-                                       ("GetCfdFractionalTimeMask"));
+        throw invalid_argument(BadMaskErrorMessage("GetCfdFractionalTimeMask"));
     unsigned int mask = 0;
     if (frequency_ == 100) {
         switch (firmware_) {
@@ -99,6 +100,9 @@ XiaListModeDataMask::GetCfdFractionalTimeMask() const {
             case R34688:
                 mask = 0x1FFF0000;
                 break;
+            case R35207:
+                mask = 0x1FFF0000;
+                break;
             default:
                 break;
         }
@@ -107,7 +111,7 @@ XiaListModeDataMask::GetCfdFractionalTimeMask() const {
 }
 
 std::pair<unsigned int, unsigned int> XiaListModeDataMask::GetEventLengthMask()
-const {
+    const {
     if (firmware_ == UNKNOWN)
         throw invalid_argument(BadMaskErrorMessage("GetEventLengthMask"));
     unsigned int mask = 0;
@@ -127,6 +131,10 @@ const {
             mask = 0x7FFE0000;
             bit = 17;
             break;
+        case R35207:
+            mask = 0x7FFE0000;
+            bit = 17;
+            break;
         default:
             break;
     }
@@ -136,8 +144,7 @@ const {
 pair<unsigned int, unsigned int>
 XiaListModeDataMask::GetCfdForcedTriggerBitMask() const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
-        throw invalid_argument(BadMaskErrorMessage
-                                       ("GetCfdForcedTriggerBitMask"));
+        throw invalid_argument(BadMaskErrorMessage("GetCfdForcedTriggerBitMask"));
     unsigned int mask = 0;
     unsigned int bit = 0;
     if (frequency_ == 100) {
@@ -173,8 +180,7 @@ XiaListModeDataMask::GetCfdForcedTriggerBitMask() const {
 pair<unsigned int, unsigned int>
 XiaListModeDataMask::GetCfdTriggerSourceMask() const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
-        throw invalid_argument(BadMaskErrorMessage
-                                       ("GetCfdTriggerSourceMask"));
+        throw invalid_argument(BadMaskErrorMessage("GetCfdTriggerSourceMask"));
     unsigned int mask = 0;
     unsigned int bit = 0;
     if (frequency_ == 250) {
@@ -206,6 +212,9 @@ XiaListModeDataMask::GetCfdTriggerSourceMask() const {
                 mask = 0xE0000000;
                 bit = 29;
                 break;
+            case R35207:
+                mask = 0xE0000000;
+                bit = 29;
             default:
                 break;
         }
@@ -216,10 +225,9 @@ XiaListModeDataMask::GetCfdTriggerSourceMask() const {
 /// The energy always starts out on Bit 0 of Word 3 so we do not need to
 /// define a variable for the bit.
 pair<unsigned int, unsigned int> XiaListModeDataMask::GetEventEnergyMask()
-const {
+    const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
-        throw invalid_argument(BadMaskErrorMessage
-                                       ("GetEventEnergyMask"));
+        throw invalid_argument(BadMaskErrorMessage("GetEventEnergyMask"));
     unsigned int mask = 0;
     switch (firmware_) {
         case R29432:
@@ -231,6 +239,7 @@ const {
         case R17562:
         case R20466:
         case R27361:
+        case R35207:
         case R34688:
             mask = 0x0000FFFF;
             break;
@@ -245,8 +254,7 @@ const {
 pair<unsigned int, unsigned int>
 XiaListModeDataMask::GetTraceOutOfRangeFlagMask() const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
-        throw invalid_argument(BadMaskErrorMessage
-                                       ("GetTraceOutOfRangeFlagMask"));
+        throw invalid_argument(BadMaskErrorMessage("GetTraceOutOfRangeFlagMask"));
 
     unsigned int mask = 0;
     unsigned int bit = 0;
@@ -264,6 +272,7 @@ XiaListModeDataMask::GetTraceOutOfRangeFlagMask() const {
             mask = 0x00008000;
             bit = 15;
             break;
+        case R35207:
         case R34688:
             mask = 0x80000000;
             bit = 31;
@@ -276,10 +285,9 @@ XiaListModeDataMask::GetTraceOutOfRangeFlagMask() const {
 
 //Trace Length always starts on bit 16 of Word 3.
 pair<unsigned int, unsigned int> XiaListModeDataMask::GetTraceLengthMask()
-const {
+    const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
-        throw invalid_argument(BadMaskErrorMessage
-                                       ("GetTraceLengthMask"));
+        throw invalid_argument(BadMaskErrorMessage("GetTraceLengthMask"));
     unsigned int mask = 0;
     switch (firmware_) {
         case R17562:
@@ -291,6 +299,7 @@ const {
         case R30981:
             mask = 0xFFFF0000;
             break;
+        case R35207:
         case R34688:
             mask = 0x7FFF0000;
             break;
@@ -310,8 +319,7 @@ string XiaListModeDataMask::BadMaskErrorMessage(const std::string &func) const {
 
 double XiaListModeDataMask::GetCfdSize() const {
     if (firmware_ == UNKNOWN || frequency_ == 0)
-        throw invalid_argument(BadMaskErrorMessage
-                                       ("GetCfdSize"));
+        throw invalid_argument(BadMaskErrorMessage("GetCfdSize"));
     if (frequency_ == 500)
         return 8192.;
 

--- a/Analysis/Utkscan/analyzers/include/CfdAnalyzer.hpp
+++ b/Analysis/Utkscan/analyzers/include/CfdAnalyzer.hpp
@@ -12,12 +12,12 @@
 
 //! Class to analyze traces using a digital CFD
 class CfdAnalyzer : public TraceAnalyzer {
-public:
+   public:
     /** Default constructor taking an argument*/
-    CfdAnalyzer(const std::string &s);
+    CfdAnalyzer(const std::string &s, const std::set<std::string> &ignoredTypes);
 
     /** Default Destructor */
-    ~CfdAnalyzer() {};
+    ~CfdAnalyzer(){};
 
     /** Declare the plots */
     void DeclarePlots(void) const {};
@@ -29,7 +29,8 @@ public:
     * \param [in] tagMap : the map of tags for the channel */
     void Analyze(Trace &trace, const ChannelConfiguration &cfg);
 
-private:
+   private:
+    std::set<std::string> ignoredTypes_;
     TimingDriver *driver_;
 };
 

--- a/Analysis/Utkscan/analyzers/include/CfdAnalyzer.hpp
+++ b/Analysis/Utkscan/analyzers/include/CfdAnalyzer.hpp
@@ -14,7 +14,7 @@
 class CfdAnalyzer : public TraceAnalyzer {
    public:
     /** Default constructor taking an argument*/
-    CfdAnalyzer(const std::string &s, const std::set<std::string> &ignoredTypes);
+    CfdAnalyzer(const std::string &s, const int &ptype, const std::set<std::string> &ignoredTypes);
 
     /** Default Destructor */
     ~CfdAnalyzer(){};

--- a/Analysis/Utkscan/analyzers/include/FittingAnalyzer.hpp
+++ b/Analysis/Utkscan/analyzers/include/FittingAnalyzer.hpp
@@ -32,7 +32,9 @@ public:
      * \param [in] detSubtype : the subtype of the detector 
      * \param [in] tagMap : the map of tags for the channel */
     void Analyze(Trace &trace, const ChannelConfiguration &cfg);
-
+    
+    //precheck of the individual analyzer's ignore list
+    bool IsIgnoredDetector(const ChannelConfiguration &id);
 private:
     TimingDriver *driver_;
     std::set<std::string> ignoredTypes_;

--- a/Analysis/Utkscan/analyzers/include/TraceAnalyzer.hpp
+++ b/Analysis/Utkscan/analyzers/include/TraceAnalyzer.hpp
@@ -25,8 +25,13 @@ public:
     /** Constructor taking histogram information
     * \param [in] offset : the offset for the histograms
     * \param [in] range : the range of the histograms
-    * \param [in] name : the name of the processor */
+    * \param [in] name : the name of the analyzer */
     TraceAnalyzer(const unsigned int &offset, const unsigned int &range, const std::string &name);
+
+    /** Constructor taking just the Analyzer Name
+    * \param [in] name : the name of the analyzer */
+    TraceAnalyzer(const std::string &name);
+
 
     /** Initializes the Analyzer
     * \return True if the init was successful */
@@ -47,12 +52,37 @@ public:
     /** Finish analysis updating the analyzer timing information */
     void EndAnalyze(void);
 
+    /** \return the level of the trace analysis */
+    int GetLevel() { return level; }
+
+    /** Get the name of the analyzer
+    * \return Name of the analyzer */
+    std::string GetName(void) const { return (name); }
+
+    /// @return true if current detector is in the list
+    bool IsIgnored(const std::set<std::string> &list, const ChannelConfiguration &id) {
+        bool retVal;
+        if (list.find(id.GetType()) != list.end()) {
+            retVal = true;
+        } else if (list.find(id.GetType() + ":" + id.GetSubtype()) != list.end()) {
+            retVal = true;
+        } else if (list.find(id.GetType() + ":" + id.GetSubtype() + ":" + id.GetGroup()) != list.end()) {
+            retVal = true;
+        } else {
+            retVal = false;
+        }
+        return retVal;
+    };
+
+    /// @return true if we should use this analyzer with the current channel
+    /// \param [in] id : current channel configuration
+    /// This is should be used for any analyzers that do parallel work, i.e 
+    /// the FittingAnalyzer and the CfdAnalyzer, so that we dont zero the work thats already been done. 
+    virtual bool IsIgnoredDetector(const ChannelConfiguration &id){return false;};
+
     /** Set the level of the trace analysis
      * \param [in] i : the level of the analysis to be done */
     void SetLevel(int i) { level = i; }
-
-    /** \return the level of the trace analysis */
-    int GetLevel() { return level; }
 
 protected:
     int level;                ///< the level of analysis to proceed with

--- a/Analysis/Utkscan/analyzers/include/TraceAnalyzer.hpp
+++ b/Analysis/Utkscan/analyzers/include/TraceAnalyzer.hpp
@@ -60,19 +60,7 @@ public:
     std::string GetName(void) const { return (name); }
 
     /// @return true if current detector is in the list
-    bool IsIgnored(const std::set<std::string> &list, const ChannelConfiguration &id) {
-        bool retVal;
-        if (list.find(id.GetType()) != list.end()) {
-            retVal = true;
-        } else if (list.find(id.GetType() + ":" + id.GetSubtype()) != list.end()) {
-            retVal = true;
-        } else if (list.find(id.GetType() + ":" + id.GetSubtype() + ":" + id.GetGroup()) != list.end()) {
-            retVal = true;
-        } else {
-            retVal = false;
-        }
-        return retVal;
-    };
+    bool IsIgnored(const std::set<std::string> &list, const ChannelConfiguration &id);       
 
     /// @return true if we should use this analyzer with the current channel
     /// \param [in] id : current channel configuration

--- a/Analysis/Utkscan/analyzers/include/WaveformAnalyzer.hpp
+++ b/Analysis/Utkscan/analyzers/include/WaveformAnalyzer.hpp
@@ -32,6 +32,7 @@ public:
 
 private:
     std::set<std::string> ignoredTypes_;
+    int extremeBaselineRejectCounter_;
 };
 
 #endif // __WAVEFORMANALYZER_HPP_

--- a/Analysis/Utkscan/analyzers/include/WaveformAnalyzer.hpp
+++ b/Analysis/Utkscan/analyzers/include/WaveformAnalyzer.hpp
@@ -30,6 +30,9 @@ public:
     * \param [in] tags : the map of the tags for the channel */
     void Analyze(Trace &trace, const ChannelConfiguration &cfg);
 
+     //precheck of the individual analyzer's ignore list
+    bool IsIgnoredDetector(const ChannelConfiguration &id);
+
 private:
     std::set<std::string> ignoredTypes_;
     int extremeBaselineRejectCounter_;

--- a/Analysis/Utkscan/analyzers/source/CfdAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/CfdAnalyzer.cpp
@@ -38,6 +38,10 @@ void CfdAnalyzer::Analyze(Trace &trace, const ChannelConfiguration &cfg) {
         EndAnalyze();
         return;
     }
+     //non destructive return if we have already done timing analysis on this channel
+    if (trace.HasValidTimingAnalysis()){
+        return;
+    }
 
     if (trace.IsSaturated() || trace.empty() || !trace.HasValidWaveformAnalysis() || IsIgnored(ignoredTypes_,cfg)) {
         trace.SetHasValidTimingAnalysis(false);

--- a/Analysis/Utkscan/analyzers/source/CfdAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/CfdAnalyzer.cpp
@@ -19,10 +19,10 @@
 
 using namespace std;
 
-CfdAnalyzer::CfdAnalyzer(const std::string &s, const std::set<std::string> &ignoredTypes) : TraceAnalyzer() {
+CfdAnalyzer::CfdAnalyzer(const std::string &s, const int &ptype, const std::set<std::string> &ignoredTypes) : TraceAnalyzer() {
     name = "CfdAnalyzer";
     if (s == "polynomial" || s == "poly"){
-        driver_ = new PolynomialCfd();
+        driver_ = new PolynomialCfd(ptype);
     }else if (s == "traditional" || s == "trad"){
         driver_ = new TraditionalCfd();
     }else {
@@ -54,6 +54,7 @@ void CfdAnalyzer::Analyze(Trace &trace, const ChannelConfiguration &cfg) {
 
     ///@TODO We do not currently have any CFDs that require L, so we are not going to pass that variable. In
     /// addition, we do not have an overloaded version of CalculatePhase that takes a tuple<double, double, double>
-    trace.SetPhase(driver_->CalculatePhase(trace.GetTraceSansBaseline(), make_pair(get<1>(pars), get<2>(pars)), trace.GetExtrapolatedMaxInfo(), trace.GetBaselineInfo()));
+    trace.SetPhase(driver_->CalculatePhase(trace.GetTraceSansBaseline(), make_pair(get<0>(pars), get<1>(pars)), trace.GetExtrapolatedMaxInfo(), trace.GetBaselineInfo()));
+    trace.SetHasValidTimingAnalysis(true);
     EndAnalyze();
 }

--- a/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
@@ -61,6 +61,11 @@ bool FittingAnalyzer::IsIgnoredDetector(const ChannelConfiguration &id) {
 void FittingAnalyzer::Analyze(Trace &trace, const ChannelConfiguration &cfg) {
     TraceAnalyzer::Analyze(trace, cfg);
 
+    //non destructive return if we have already done timing analysis on this channel
+    if (trace.HasValidTimingAnalysis()){
+        return;
+    }
+
     if (trace.IsSaturated() || trace.empty() || !trace.HasValidWaveformAnalysis() || IsIgnored(ignoredTypes_,cfg)) {
         trace.SetHasValidTimingAnalysis(false);
         EndAnalyze();

--- a/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/FittingAnalyzer.cpp
@@ -63,7 +63,7 @@ void FittingAnalyzer::Analyze(Trace &trace, const ChannelConfiguration &cfg) {
     ignoredTypes_.find(cfg.GetType() + ":" + cfg.GetSubtype()) != ignoredTypes_.end() ||
     ignoredTypes_.find(cfg.GetType() + ":" + cfg.GetSubtype() + ":" + cfg.GetGroup()) != ignoredTypes_.end()) {
         trace.SetPhase(0.0);
-        trace.SetHasValidFitAnalysis(false);
+        trace.SetHasValidTimingAnalysis(false);
         EndAnalyze();
         return;
     }
@@ -74,6 +74,6 @@ void FittingAnalyzer::Analyze(Trace &trace, const ChannelConfiguration &cfg) {
         driver_->SetIsFastSiPm(true);
 
     trace.SetPhase(driver_->CalculatePhase(trace.GetWaveform(), cfg.GetFittingParameters(), trace.GetMaxInfo(),trace.GetBaselineInfo()) + trace.GetMaxInfo().first);
-    trace.SetHasValidFitAnalysis(true);
+    trace.SetHasValidTimingAnalysis(true);
     EndAnalyze();
 }

--- a/Analysis/Utkscan/analyzers/source/TraceAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/TraceAnalyzer.cpp
@@ -91,14 +91,14 @@ void TraceAnalyzer::EndAnalyze(void) {
 }
 
 bool TraceAnalyzer::IsIgnored(const std::set<std::string> &list, const ChannelConfiguration &id){ bool retVal;
-        if (list.find(id.GetType()) != list.end()) {
-            retVal = true;
-        } else if (list.find(id.GetType() + ":" + id.GetSubtype()) != list.end()) {
-            retVal = true;
-        } else if (list.find(id.GetType() + ":" + id.GetSubtype() + ":" + id.GetGroup()) != list.end()) {
-            retVal = true;
-        } else {
-            retVal = false;
-        }
-        return retVal;
-    };
+    if (list.find(id.GetType()) != list.end()) {
+        retVal = true;
+    } else if (list.find(id.GetType() + ":" + id.GetSubtype()) != list.end()) {
+        retVal = true;
+    } else if (list.find(id.GetType() + ":" + id.GetSubtype() + ":" + id.GetGroup()) != list.end()) {
+        retVal = true;
+    } else {
+        retVal = false;
+    }
+    return retVal;
+}

--- a/Analysis/Utkscan/analyzers/source/TraceAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/TraceAnalyzer.cpp
@@ -89,3 +89,16 @@ void TraceAnalyzer::EndAnalyze(void) {
     //   derived classes work properly
     times(&tmsBegin);
 }
+
+bool TraceAnalyzer::IsIgnored(const std::set<std::string> &list, const ChannelConfiguration &id){ bool retVal;
+        if (list.find(id.GetType()) != list.end()) {
+            retVal = true;
+        } else if (list.find(id.GetType() + ":" + id.GetSubtype()) != list.end()) {
+            retVal = true;
+        } else if (list.find(id.GetType() + ":" + id.GetSubtype() + ":" + id.GetGroup()) != list.end()) {
+            retVal = true;
+        } else {
+            retVal = false;
+        }
+        return retVal;
+    };

--- a/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
@@ -25,9 +25,17 @@ WaveformAnalyzer::WaveformAnalyzer(const std::set<std::string> &ignoredTypes)
     extremeBaselineRejectCounter_ = 0;
 }
 
+bool WaveformAnalyzer::IsIgnoredDetector(const ChannelConfiguration &id) {
+    if (IsIgnored(ignoredTypes_, id)) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 void WaveformAnalyzer::Analyze(Trace &trace, const ChannelConfiguration &cfg) {
     TraceAnalyzer::Analyze(trace, cfg);
-    if (trace.IsSaturated() || trace.empty() || ignoredTypes_.find(cfg.GetType()) != ignoredTypes_.end() || ignoredTypes_.find(cfg.GetType() + ":" + cfg.GetSubtype()) != ignoredTypes_.end() || ignoredTypes_.find(cfg.GetType() + ":" + cfg.GetSubtype() + ":" + cfg.GetGroup()) != ignoredTypes_.end()) {
+    if (trace.IsSaturated() || trace.empty() || IsIgnored(ignoredTypes_,cfg)) {
         trace.SetHasValidWaveformAnalysis(false);
         EndAnalyze();
         return;

--- a/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
+++ b/Analysis/Utkscan/analyzers/source/WaveformAnalyzer.cpp
@@ -83,7 +83,7 @@ void WaveformAnalyzer::Analyze(Trace &trace, const ChannelConfiguration &cfg) {
         //Also if the avg baseline is lower than 10 ADC units (for any bit resolution),
         // this is also a sign of a bad trace capture.
         
-        static const double extremeBaselineVariation = 0.15 * baseline.first; //Checking for an std of 15% of the avg baseline (this way we are sensitive to the different bit resolutions)
+        const double extremeBaselineVariation = 0.15 * baseline.first; //Checking for an std of 15% of the avg baseline (this way we are sensitive to the different bit resolutions)
         if (baseline.second >= extremeBaselineVariation || baseline.first <= 10) {
             extremeBaselineRejectCounter_++;
             trace.SetHasValidWaveformAnalysis(false);

--- a/Analysis/Utkscan/core/include/HighResTimingData.hpp
+++ b/Analysis/Utkscan/core/include/HighResTimingData.hpp
@@ -36,7 +36,7 @@ public:
     ///@return True if the trace was successfully analyzed and we managed to
     /// find a phase.
     bool GetIsValid() const {
-        if (GetTrace().HasValidWaveformAnalysis() && GetTrace().HasValidFitAnalysis() && GetTrace().GetPhase() != 0.0)
+        if (GetTrace().HasValidWaveformAnalysis() && GetTrace().HasValidTimingAnalysis() && GetTrace().GetPhase() != 0.0)
             return (true);
         return (false);
     }

--- a/Analysis/Utkscan/core/include/PaassRootStruct.hpp
+++ b/Analysis/Utkscan/core/include/PaassRootStruct.hpp
@@ -98,7 +98,7 @@ struct ROOTDEV {
     double extMaxVal = -999;                 // Extrapolated Max value in the trace (requires the Waveform Analyzer)
     double highResTime = -999;               //High Resolution Time derived from the trace fitting (requires the Waveform and Fitting Analyzer)
     std::vector<unsigned int> qdcSums = {};  //output the onboard qdc sums if present
-    bool hasValidFitAnalysis = false;
+    bool hasValidTimingAnalysis = false;
     bool hasValidWaveformAnalysis = false;
 };
 static const ROOTDEV ROOTDEV_DEFAULT_STRUCT;

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -334,10 +334,10 @@ int DetectorDriver::ThreshAndCal(ChanEvent *chan, RawEvent &rawev) {
 
             
         if(chan->GetTrace().HasValidWaveformAnalysis()){
-        plot(D_HAS_TRACE_2,id);
+            plot(D_HAS_TRACE_2,id);
         }
-        if(chan->GetTrace().HasValidFitAnalysis()){
-        plot(D_HAS_TRACE_3,id);
+        if(chan->GetTrace().HasValidTimingAnalysis()){
+            plot(D_HAS_TRACE_3,id);
         }
         //We are going to handle the filtered energies here.
         vector<double> filteredEnergies = trace.GetFilteredEnergies();

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -328,6 +328,10 @@ int DetectorDriver::ThreshAndCal(ChanEvent *chan, RawEvent &rawev) {
 
     if (!trace.empty()) {
         plot(D_HAS_TRACE, id);
+        
+        //!Setting these to false initally so that we can guarante that its false either if we are ignored or if it fails in the analyzers. 
+        chan->GetTrace().SetHasValidWaveformAnalysis(false);
+        chan->GetTrace().SetHasValidTimingAnalysis(false);
 
         for (vector<TraceAnalyzer *>::iterator it = vecAnalyzer.begin(); it != vecAnalyzer.end(); it++){
             if (!(*it)->IsIgnoredDetector(chanCfg)){

--- a/Analysis/Utkscan/core/source/DetectorDriver.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriver.cpp
@@ -329,15 +329,19 @@ int DetectorDriver::ThreshAndCal(ChanEvent *chan, RawEvent &rawev) {
     if (!trace.empty()) {
         plot(D_HAS_TRACE, id);
 
-        for (vector<TraceAnalyzer *>::iterator it = vecAnalyzer.begin(); it != vecAnalyzer.end(); it++)
-            (*it)->Analyze(trace, chanCfg);
+        for (vector<TraceAnalyzer *>::iterator it = vecAnalyzer.begin(); it != vecAnalyzer.end(); it++){
+            if (!(*it)->IsIgnoredDetector(chanCfg)){
+                (*it)->Analyze(trace, chanCfg);
+            }
+        }
 
-            
         if(chan->GetTrace().HasValidWaveformAnalysis()){
             plot(D_HAS_TRACE_2,id);
         }
         if(chan->GetTrace().HasValidTimingAnalysis()){
             plot(D_HAS_TRACE_3,id);
+        } else {
+            trace.SetPhase(0.0); // if the timing analysis fails for any reason then set the phase to 0
         }
         //We are going to handle the filtered energies here.
         vector<double> filteredEnergies = trace.GetFilteredEnergies();

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -238,7 +238,7 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
                 StringManipulation::TokenizeString(processor.attribute("types").as_string("medium"), ","),
                 processor.attribute("res").as_double(2.0), processor.attribute("offset").as_double(1000.0),
                 processor.attribute("NumStarts").as_uint(1), processor.attribute("compression").as_double(1.0),
-                processor.attribute("qdcmin").as_double(0.0), processor.attribute("tofcut").as_double(-1000.0), processor.attribute("idealfp").as_double(100)));
+                processor.attribute("qdcmin").as_double(0.0), processor.attribute("tofcut").as_double(-1000.0), processor.attribute("idealfp").as_double(100),processor.attribute("onlydoubles").as_bool("false")));
         }
 #ifdef useroot  //Certain processors REQUIRE ROOT to actually work
         else if (name == "Anl1471Processor") {

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -273,7 +273,8 @@ vector<TraceAnalyzer *> DetectorDriverXmlParser::ParseAnalyzers(const pugi::xml_
 
         if (name == "CfdAnalyzer") {
             std::vector<std::string> tokens = StringManipulation::TokenizeString(analyzer.attribute("ignored").as_string(""), ",");
-            vecAnalyzer.push_back(new CfdAnalyzer(analyzer.attribute("type").as_string("poly"),std::set<std::string>(tokens.begin(), tokens.end())));
+            vecAnalyzer.push_back(new CfdAnalyzer(analyzer.attribute("type").as_string("poly"),
+            analyzer.attribute("ptype").as_int(1), std::set<std::string>(tokens.begin(), tokens.end())));
         } else if (name == "FittingAnalyzer") {
             std::vector<std::string> tokens = StringManipulation::TokenizeString(analyzer.attribute("ignored").as_string(""), ",");
             vecAnalyzer.push_back(new FittingAnalyzer(analyzer.attribute("type").as_string("gsl"), std::set<std::string>(tokens.begin(), tokens.end())));

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -272,7 +272,8 @@ vector<TraceAnalyzer *> DetectorDriverXmlParser::ParseAnalyzers(const pugi::xml_
         messenger_.detail("Loading " + name);
 
         if (name == "CfdAnalyzer") {
-            vecAnalyzer.push_back(new CfdAnalyzer(analyzer.attribute("type").as_string("poly")));
+            std::vector<std::string> tokens = StringManipulation::TokenizeString(analyzer.attribute("ignored").as_string(""), ",");
+            vecAnalyzer.push_back(new CfdAnalyzer(analyzer.attribute("type").as_string("poly"),std::set<std::string>(tokens.begin(), tokens.end())));
         } else if (name == "FittingAnalyzer") {
             std::vector<std::string> tokens = StringManipulation::TokenizeString(analyzer.attribute("ignored").as_string(""), ",");
             vecAnalyzer.push_back(new FittingAnalyzer(analyzer.attribute("type").as_string("gsl"), std::set<std::string>(tokens.begin(), tokens.end())));

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -238,7 +238,7 @@ vector<EventProcessor *> DetectorDriverXmlParser::ParseProcessors(const pugi::xm
                 StringManipulation::TokenizeString(processor.attribute("types").as_string("medium"), ","),
                 processor.attribute("res").as_double(2.0), processor.attribute("offset").as_double(1000.0),
                 processor.attribute("NumStarts").as_uint(1), processor.attribute("compression").as_double(1.0),
-                processor.attribute("qdcmin").as_double(0.0), processor.attribute("tofcut").as_double(-1000.0), processor.attribute("idealfp").as_double(100),processor.attribute("onlydoubles").as_bool("false")));
+                processor.attribute("qdcmin").as_double(0.0), processor.attribute("tofcut").as_double(-1000.0), processor.attribute("idealfp").as_double(100)));
         }
 #ifdef useroot  //Certain processors REQUIRE ROOT to actually work
         else if (name == "Anl1471Processor") {

--- a/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/DetectorDriverXmlParser.cpp
@@ -287,8 +287,7 @@ vector<TraceAnalyzer *> DetectorDriverXmlParser::ParseAnalyzers(const pugi::xml_
         } else if (name == "WaaAnalyzer") {
             vecAnalyzer.push_back(new WaaAnalyzer());
         } else if (name == "WaveformAnalyzer") {
-            std::vector<std::string> tokens =
-                StringManipulation::TokenizeString(analyzer.attribute("ignored").as_string(""), ",");
+            std::vector<std::string> tokens = StringManipulation::TokenizeString(analyzer.attribute("ignored").as_string(""), ",");
             vecAnalyzer.push_back(new WaveformAnalyzer(std::set<std::string>(tokens.begin(), tokens.end())));
         } else {
             stringstream ss;

--- a/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
@@ -130,7 +130,7 @@ void MapNodeXmlParser::ParseNode(DetectorLibrary *lib) {
             else if (isVerbose)
                 messenger_.detail("This channel has no calibration associated with it.", 2);
 
-            if (channel.child("Cfd"))
+            if (channel.child("Cfd") || isVandle)
                 ParseCfdNode(channel.child("Cfd"), chanCfg, isVerbose);
             else if (isVerbose)
                 messenger_.detail("Using default CFD settings for this channel.", 2);

--- a/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
+++ b/Analysis/Utkscan/core/source/MapNodeXmlParser.cpp
@@ -215,9 +215,9 @@ void MapNodeXmlParser::ParseCalibrations(const pugi::xml_node &node, const Chann
 /// Parameter node must also exist.
 void MapNodeXmlParser::ParseCfdNode(const pugi::xml_node &node, ChannelConfiguration &config, const bool &isVerbose) {
         config.SetCfdParameters(make_tuple(
-                node.child("Cfd").attribute("f").as_double(DefaultConfig::cfdF),
-                node.child("Cfd").attribute("d").as_double(DefaultConfig::cfdD),
-                node.child("Cfd").attribute("l").as_double(DefaultConfig::cfdL)));
+                node.attribute("f").as_double(DefaultConfig::cfdF),
+                node.attribute("d").as_double(DefaultConfig::cfdD),
+                node.attribute("l").as_double(DefaultConfig::cfdL)));
 }
 
 ///This method parses the fitting node. There are only two free parameters at the moment. The main part of this node

--- a/Analysis/Utkscan/processors/include/GeProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/GeProcessor.hpp
@@ -25,6 +25,9 @@ public:
 
     ///Declare the plots for the processor
     virtual void DeclarePlots(void);
+
+private:
+    processor_struct::CLOVERS GEstruct;
 };
 
 #endif // __GEPROCESSOR_HPP_

--- a/Analysis/Utkscan/processors/include/VandleProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/VandleProcessor.hpp
@@ -40,9 +40,7 @@ public:
     ///@param [in] res : The resolution of the DAMM histograms
     ///@param [in] offset : The offset of the DAMM histograms 
     ///@param [in] numStarts : number of starts we have to process */
-    VandleProcessor(const std::vector<std::string> &typeList, const double &res, const double &offset,
-                    const unsigned int &numStarts, const double &compression , const double &qdcmin,
-                    const double &tofcut, const double &idealFP);
+    VandleProcessor(const std::vector<std::string> &typeList, const double &res, const double &offset, const unsigned int &numStarts, const double &compression , const double &qdcmin, const double &tofcut, const double &idealFP,  const bool &onlyDoubles);
 
     ///Preprocess the VANDLE data
     ///@param [in] event : the event to preprocess
@@ -85,9 +83,9 @@ private:
     ///Fill up the basic histograms
     void FillVandleOnlyHists();
 
-    void PlotTofHistograms(const double &tof, const double &cortof,const double &NCtof, const double &qdc,
-                           const unsigned int &barPlusStartLoc, const std::pair<unsigned int, unsigned int> &offset,
-                           bool &calibrated );
+    void PlotTofHistograms(const double &tof, const double &cortof,const double &NCtof, const double &qdc, const unsigned int &barPlusStartLoc, const std::pair<unsigned int, unsigned int> &offset, bool &calibrated );
+
+
 
     ///@return Returns a pair of the appropriate offsets based off the VANDLE bar type <calibrated, NonCalibrated>
     ///@param [in] type : The type of bar that we are dealing with
@@ -109,7 +107,7 @@ private:
     double qdcmin_;//!<min qdc to add to root tree, used to help speed up nearline mergers etc
     double tofcut_;//!< min tof to add to root tree for speeding up near line merger
 
-
+    bool onlyDoubles_; //!< True if only doing doubles related things (gain match checking etc) and this is really directed at the ROOT output rather than DAMMs
     bool hasSmall_; //!< True if small bars were requested in the Config
     bool hasBig_; //!< True if big bars were requested in the Config
     bool hasMed_; //!< True if medium bars were requested in the Config

--- a/Analysis/Utkscan/processors/include/VandleProcessor.hpp
+++ b/Analysis/Utkscan/processors/include/VandleProcessor.hpp
@@ -40,7 +40,9 @@ public:
     ///@param [in] res : The resolution of the DAMM histograms
     ///@param [in] offset : The offset of the DAMM histograms 
     ///@param [in] numStarts : number of starts we have to process */
-    VandleProcessor(const std::vector<std::string> &typeList, const double &res, const double &offset, const unsigned int &numStarts, const double &compression , const double &qdcmin, const double &tofcut, const double &idealFP,  const bool &onlyDoubles);
+    VandleProcessor(const std::vector<std::string> &typeList, const double &res, const double &offset,
+                    const unsigned int &numStarts, const double &compression , const double &qdcmin,
+                    const double &tofcut, const double &idealFP);
 
     ///Preprocess the VANDLE data
     ///@param [in] event : the event to preprocess
@@ -83,9 +85,9 @@ private:
     ///Fill up the basic histograms
     void FillVandleOnlyHists();
 
-    void PlotTofHistograms(const double &tof, const double &cortof,const double &NCtof, const double &qdc, const unsigned int &barPlusStartLoc, const std::pair<unsigned int, unsigned int> &offset, bool &calibrated );
-
-
+    void PlotTofHistograms(const double &tof, const double &cortof,const double &NCtof, const double &qdc,
+                           const unsigned int &barPlusStartLoc, const std::pair<unsigned int, unsigned int> &offset,
+                           bool &calibrated );
 
     ///@return Returns a pair of the appropriate offsets based off the VANDLE bar type <calibrated, NonCalibrated>
     ///@param [in] type : The type of bar that we are dealing with
@@ -107,7 +109,7 @@ private:
     double qdcmin_;//!<min qdc to add to root tree, used to help speed up nearline mergers etc
     double tofcut_;//!< min tof to add to root tree for speeding up near line merger
 
-    bool onlyDoubles_; //!< True if only doing doubles related things (gain match checking etc) and this is really directed at the ROOT output rather than DAMMs
+
     bool hasSmall_; //!< True if small bars were requested in the Config
     bool hasBig_; //!< True if big bars were requested in the Config
     bool hasMed_; //!< True if medium bars were requested in the Config

--- a/Analysis/Utkscan/processors/source/GeProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/GeProcessor.cpp
@@ -2,9 +2,11 @@
 ///@brief Implementation for germanium processor
 ///@author D. Miller, K. Miernik, S. V. Paulauskas
 ///@date August 2009
+#include "GeProcessor.hpp"
+
 #include <algorithm>
-#include <cstdlib>
 #include <cmath>
+#include <cstdlib>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -13,22 +15,22 @@
 #include <sstream>
 
 #include "DammPlotIds.hpp"
+#include "DetectorDriver.hpp"
 #include "DetectorLibrary.hpp"
 #include "Exceptions.hpp"
-#include "GeProcessor.hpp"
 #include "Messenger.hpp"
 
 namespace dammIds {
-    namespace ge {
-        const int DD_ENERGY = 0;//!< Energy
-    }
+namespace ge {
+const int DD_ENERGY = 0;  //!< Energy
 }
+}  // namespace dammIds
 
 using namespace std;
 using namespace dammIds::ge;
 
 GeProcessor::GeProcessor() : EventProcessor(OFFSET, RANGE, "GeProcessor") {
-    associatedTypes.insert("ge"); // associate with germanium detectors
+    associatedTypes.insert("ge");  // associate with germanium detectors
 }
 
 void GeProcessor::DeclarePlots(void) {
@@ -40,16 +42,27 @@ bool GeProcessor::PreProcess(RawEvent &event) {
         return false;
 
     static const vector<ChanEvent *> &geEvents =
-            event.GetSummary("ge", true)->GetList();
+        event.GetSummary("ge", true)->GetList();
 
     for (vector<ChanEvent *>::const_iterator ge = geEvents.begin();
          ge != geEvents.end(); ge++) {
-
         if ((*ge)->IsSaturated() || (*ge)->IsPileup())
             continue;
 
         plot(DD_ENERGY, (*ge)->GetCalibratedEnergy(),
              (*ge)->GetChanID().GetLocation());
+
+        if (DetectorDriver::get()->GetSysRootOutput()) {
+            int module_freq = (*ge)->GetChanID().GetModFreq();
+            //We are reusing the Clover Stuct definition. This means these well go into the clover_vec_
+            GEstruct.rawEnergy = (*ge)->GetEnergy();
+            GEstruct.energy = (*ge)->GetCalibratedEnergy();
+            GEstruct.time = (*ge)->GetTimeSansCfd() * Globals::get()->GetClockInSeconds(module_freq) * 1e9;  //store ns
+            GEstruct.detNum = (*ge)->GetChanID().GetLocation();
+            GEstruct.cloverNum = -1; //We Define the Single Channel Ge detectors to be cloverNum -1 so that we can use both clovers and single channels at the same time. 
+            pixie_tree_event_->clover_vec_.emplace_back(GEstruct);
+            GEstruct = processor_struct::CLOVERS_DEFAULT_STRUCT;  //reset to initalized values (see PaassRootStruct.hpp
+        }
     }
     return true;
 }

--- a/Analysis/Utkscan/processors/source/RootDevProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/RootDevProcessor.cpp
@@ -57,7 +57,7 @@ bool RootDevProcessor::Process(RawEvent &event) {
         RDstruct.saturation = (*it)->IsSaturated();
 
         if ((*it)->GetTrace().size() > 0) {
-            RDstruct.hasValidFitAnalysis = (*it)->GetTrace().HasValidFitAnalysis();
+            RDstruct.hasValidTimingAnalysis = (*it)->GetTrace().HasValidTimingAnalysis();
             RDstruct.hasValidWaveformAnalysis = (*it)->GetTrace().HasValidWaveformAnalysis();
             RDstruct.baseline = (*it)->GetTrace().GetBaselineInfo().first;
             RDstruct.stdBaseline = (*it)->GetTrace().GetBaselineInfo().second;

--- a/Analysis/Utkscan/processors/source/SingleBetaProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/SingleBetaProcessor.cpp
@@ -49,7 +49,7 @@ bool SingleBetaProcessor::PreProcess(RawEvent &event) {
 
         double evtTick2Ns = Globals::get()->GetClockInSeconds((*itE)->GetChanID().GetModFreq()) * 1e9;
 
-        if ((*itE)->GetChanID().HasTag("start") && (*itE)->GetTrace().HasValidFitAnalysis()) {
+        if ((*itE)->GetChanID().HasTag("start") && (*itE)->GetTrace().HasValidTimingAnalysis()) {
             plot(DD_QDC, (*itE)->GetTrace().GetQdc(), (*itE)->GetChanID().GetLocation());
             plot(DD_BETAMAXXVAL, (*itE)->GetTrace().GetMaxInfo().second, (*itE)->GetChanID().GetLocation());
 
@@ -60,7 +60,7 @@ bool SingleBetaProcessor::PreProcess(RawEvent &event) {
                 SBstruc.tMaxVal = (*itE)->GetTrace().GetMaxInfo().second;
                 SBstruc.hasTraceFit = true;
             }
-        } else if ((*itE)->GetChanID().HasTag("start") && !(*itE)->GetTrace().HasValidFitAnalysis()) {  //! Start Beta, without a valid fit for the trace (I.e no trace, ignored or Onboard CFD)
+        } else if ((*itE)->GetChanID().HasTag("start") && !(*itE)->GetTrace().HasValidTimingAnalysis()) {  //! Start Beta, without a valid fit for the trace (I.e no trace, ignored or Onboard CFD)
             plot(DD_HIGHEN, (*itE)->GetCalibratedEnergy(), (*itE)->GetChanID().GetLocation());
 
             if (DetectorDriver::get()->GetSysRootOutput()) {

--- a/Analysis/Utkscan/processors/source/VandleProcessor.cpp
+++ b/Analysis/Utkscan/processors/source/VandleProcessor.cpp
@@ -56,8 +56,8 @@ VandleProcessor::VandleProcessor() : EventProcessor(OFFSET, RANGE, "VandleProces
 }
 
 VandleProcessor::VandleProcessor(const std::vector<std::string> &typeList, const double &res, const double &offset,
-                                 const unsigned int &numStarts, const double &compression/*=1.0*/,const double &qdcmin,
-                                 const double &tofcut, const double &idealFP) :
+                                 const unsigned int &numStarts, const double &compression,const double &qdcmin,
+                                 const double &tofcut, const double &idealFP, const bool &onlyDoubles) :
         EventProcessor(OFFSET,RANGE,"VandleProcessor") {
     associatedTypes.insert("vandle");
     plotMult_ = res;
@@ -67,6 +67,7 @@ VandleProcessor::VandleProcessor(const std::vector<std::string> &typeList, const
     qdcmin_ = qdcmin;
     tofcut_ = tofcut;
     idealFP_ = idealFP;
+    onlyDoubles_ = onlyDoubles;
 
     if(typeList.empty())
         requestedTypes_.insert("small");
@@ -196,8 +197,7 @@ void VandleProcessor::AnalyzeBarStarts(const BarDetector &bar, unsigned int &bar
             double corTof = CorrectTOF(tof, bar.GetFlightPath(), idealFP_);
             double NCtof = bar.GetCorTimeAve() - start.GetCorTimeAve() ;
 
-            PlotTofHistograms(tof, corTof,NCtof, bar.GetQdc(), barLoc * numStarts_ + startLoc,
-                              ReturnOffset(bar.GetType()),caled);
+            PlotTofHistograms(tof, corTof,NCtof, bar.GetQdc(), barLoc * numStarts_ + startLoc, ReturnOffset(bar.GetType()),caled);
 
             if (DetectorDriver::get()->GetSysRootOutput()){
                 //Fill Root struct
@@ -244,8 +244,7 @@ void VandleProcessor::AnalyzeStarts(const BarDetector &bar, unsigned int &barLoc
             double corTof = CorrectTOF(tof, bar.GetFlightPath(), idealFP_);
             double NCtof =bar.GetCorTimeAve() - startTime ;
 
-            PlotTofHistograms(tof, corTof, NCtof,bar.GetQdc(), barLoc * numStarts_ + startLoc,
-                              ReturnOffset(bar.GetType()),caled);
+            PlotTofHistograms(tof, corTof, NCtof,bar.GetQdc(), barLoc * numStarts_ + startLoc, ReturnOffset(bar.GetType()),caled);
             if (DetectorDriver::get()->GetSysRootOutput()){
 
                 if (tof>= tofcut_ && bar.GetQdc()>qdcmin_) {
@@ -319,6 +318,7 @@ void VandleProcessor::PlotTofHistograms(const double &tof, const double &cortof,
 void VandleProcessor::FillVandleOnlyHists(void) {
     for (BarMap::const_iterator it = bars_.begin(); it != bars_.end(); it++) {
         TimingDefs::TimingIdentifier barId = (*it).first;
+        BarDetector bar = (*it).second;
         unsigned int OFFSET = ReturnOffset(barId.second).first;
         unsigned int NOCALOFFSET = ReturnOffset(barId.second).second;
         double NoCalTDiff = (*it).second.GetLeftSide().GetHighResTimeInNs()-(*it).second.GetRightSide().GetHighResTimeInNs();
@@ -332,8 +332,24 @@ void VandleProcessor::FillVandleOnlyHists(void) {
         plot(DD_TIMEDIFFBARS + OFFSET, (*it).second.GetTimeDifference() * plotMult_ + plotOffset_, barId.first);
         plot(DD_TIMEDIFFBARS + NOCALOFFSET, NoCalTDiff* plotMult_ + plotOffset_, barId.first);
 
-        if (RDecay_)
+        if (RDecay_){
             plot(DD_TDIFF_DECAY+ OFFSET, (*it).second.GetTimeDifference() * plotMult_ + plotOffset_, barId.first);
+        }
+        if (DetectorDriver::get()->GetSysRootOutput() && onlyDoubles_) {
+            //Fill Root struct
+            vandles.qdc = bar.GetQdc();
+            vandles.barNum = barId.first;
+
+            vandles.barType = bar.GetType();
+            vandles.tDiff = bar.GetTimeDifference();
+            vandles.qdcPos = bar.GetQdcPosition();
+            vandles.tAvg = bar.GetTimeAverage();
+            vandles.wcTavg = bar.GetCorTimeAve();
+            vandles.wcTdiff = bar.GetCorTimeDiff();
+
+            pixie_tree_event_->vandle_vec_.emplace_back(vandles);
+            vandles = processor_struct::VANDLES_DEFAULT_STRUCT;
+        }
     }
 }
 

--- a/Core/include/CTerminal.h
+++ b/Core/include/CTerminal.h
@@ -247,6 +247,9 @@ public:
 
     /// Close the window and restore control to the terminal
     void Close();
+
+    /// Clear's the current cmd line in the poll2 prompt. (This is a wrapper of the internal clear_() command, we probably should reimplement it rather than just wrapping a private member function. )
+    void ClearCmd();
 };
 
 /// Split a string about some delimiter.

--- a/Core/source/CTerminal.cpp
+++ b/Core/source/CTerminal.cpp
@@ -307,6 +307,8 @@ void Terminal::clear_() {
     refresh_();
 }
 
+void Terminal::ClearCmd() {Terminal::clear_();}
+
 /**Creates a status window and the refreshes the output. Takes an optional number of lines, defaulted to 1.
  *
  * \param[in] numLines Vertical size of status window.

--- a/Core/source/CTerminal.cpp
+++ b/Core/source/CTerminal.cpp
@@ -995,9 +995,13 @@ Terminal::GetCommand(std::string &args, const int &prev_cmd_return_/*=0*/) {
                 wdelch(input_window);
                 //Remove character from cmd string
                 cmd.erase(cursX - offset, 1);
-            } else if (keypress ==
-                       KEY_IC) { insertMode_ = true; } // Insert key (331)
-            else if (keypress == KEY_HOME) { cursX = offset; }
+            } else if (keypress == KEY_IC) { // Insert key (331)
+                if (insertMode_){
+                    insertMode_ = false;
+                } else {
+                    insertMode_ = true; 
+                }
+            }else if (keypress == KEY_HOME) { cursX = offset; }
             else if (keypress == KEY_END) { cursX = cmd.length() + offset; }
             else if (keypress == KEY_MOUSE) { //Handle mouse events
                 MEVENT mouseEvent;

--- a/Resources/include/HelperEnumerations.hpp
+++ b/Resources/include/HelperEnumerations.hpp
@@ -26,13 +26,15 @@ namespace DataProcessing {
     /// * R29432 is valid from 02/15/2014 to 07/28/2014
     /// * R30474, R30980, R30981 is valid from 07/28/2014 to 03/08/2016
     /// * R34688 is valid from 03/08/2016
+    /// * R35207 is for the 14bit 500MHz valid from 01/01/2019
+    /// * R42159 is valid from 04/30/2019 and is primarly for 12b 250MHz (testing as R34688 decode)
     /// * UNKNOWN is used for unspecified firmware revisions.
     ///These dates do not imply that the particular data set being analyzed was
     /// taken with the expected firmware. These dates are meant only to help
     /// guide the user if they do not know the particular firmware that was used
     /// to obtain their data set.
     enum FIRMWARE {
-        R17562, R20466, R27361, R29432, R30474, R30980, R30981, R34688, UNKNOWN
+      R17562, R20466, R27361, R29432, R30474, R30980, R30981, R34688, R35207, UNKNOWN
     };
 
     ///An enumeration that tells how long headers from the XIA List mode data

--- a/Resources/include/HelperFunctions.hpp
+++ b/Resources/include/HelperFunctions.hpp
@@ -18,6 +18,25 @@
 using namespace std;
 
 namespace Polynomial {
+template <class T>
+static const pair<double, vector<double> > CalculatePoly1(
+    const vector<T> &data, const unsigned int &startBin) {
+    if (data.size() < 2)
+        throw range_error(
+            "Polynomial::CalculatePoly1 - The data vector "
+            "had the wrong size : " +
+            std::to_string(data.size()));
+
+    double x[2] = {(double)startBin, (double)startBin + 1};
+
+    double p1 = (data[x[1]] - data[x[0]]) / (x[1] - x[0]);
+
+    double p0 = data[x[1]] - p1 * x[1];
+
+    vector<double> coeffs = {p0, p1};
+
+    return make_pair(p1, coeffs);
+    }
     template<class T>
     static const pair<double, vector<double> > CalculatePoly2(
             const vector<T> &data, const unsigned int &startBin) {


### PR DESCRIPTION
This branch includes upgrades stemming from the work testing the mixed bit same frequency capabilities of utkscan(or).

This branch has been in use with multiple analyses, and are considered stable enough for merging into dev.

Highlights include:
Protections for the poll2 command "toggle". Previously if you gave an invalid bit name (polarity, gain, traces, etc.) toggle would flip bit 0. This behavior has been fixed by having the name -> bit list check fail and output an error before the call to the API.

We also added some safety checks to toggle, adjust_offsets, pwrite and pmwrite. For whatever reason the API lacks sanity checks for these functions and will let you try to run them on a module that is not installed. (a 3 module system would let you write to module 3 rather than just 0,1,2) this would cause the computer to Hard lock and require a power button forced reboot. pread and pmread had protections in the API but i have added our checks as well for consistency's sake. 

We have added support for the 42159 and 42950 ( the newest vandle firmwares 12b, and 16b respectively) 
We have also added support for parsing the 500MHz general firmware. Right now this is Hard matched since we only have 1. This will be fixed once we have more firmwares, and the parsing functions have been updated to reflect the differences in the list more format (specifically Header Word 2 which is structured differently since the "forced trigger bit is now 3 bits )

We have made Ctrl+c clear the line in poll2, rather than just spitting out an error saying we blocked the keystroke 
We have also fixed the INS key behavior, previously you could enter "insert"/"overwrite" mode but were unable to exit it. 

We have given the CfdAnalyzer some of the upgrades that were previously given to the Fitting and Waveform analyzers. Namly the ignore list.

We fixed the MapNodeXmlParser's parsing of the Cfd Parameters, and we have made the parser ALWAYs parse the cfd node for the "vandle" type, which is also done for the Fit and Trace nodes.

Finally the GeProcessor has gotten root output support. It is filled into the clover_vec_  with cloverNum = -1, since detNum is type:subtype specific. This will let us use the two processors together and identify them later in the root analysis. 

