### PR TITLE
plx.service fix

### DIFF
--- a/Share/plx/systemd/plx.service
+++ b/Share/plx/systemd/plx.service
@@ -1,14 +1,15 @@
-# @author S.V. Paulauskas
+# @author T.T. King, S.V. Paulauskas
 
 [Unit]
 Description=Service file for PLX Driver 9054 for communication with XIA Pixie16 Modules
+After=graphical.target
 
 [Service]
 Type=oneshot
-Environment="PLX_SDK_DIR=/opt/plx/current/PlxSdk"
-ExecStart=/bin/bash /opt/plx/current/PlxSdk/Bin/Plx_load 9054
-ExecStop=/bin/bash /opt/plx/current/PlxSdk/Bin/Plx_unload 9054
+Environment="PLX_SDK_DIR=/opt/plx/current/"
+ExecStart=/bin/bash -c '/opt/plx/current/Bin/Plx_load 9054'
+ExecStop=/bin/bash -c '/opt/plx/current/Bin/Plx_unload 9054'
 RemainAfterExit=yes
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical.target


### PR DESCRIPTION
Fix the plx systemd service to make it compatible with new systemd versions. 

At some point they changed some things with respect to the Exec commands, and the target order.

This commit makes the necessary changes to make it compatible. It has been tested on the pizzabox1 and pixieIDS daqs (fully yum updated as of July 10, 2020)