### PR TITLE
Adding support for PixieSDK 3.1.0

### DIFF
--- a/Acquisition/Interface/include/PixieInterface.h
+++ b/Acquisition/Interface/include/PixieInterface.h
@@ -4,7 +4,7 @@
 #ifndef __PIXIEINTERFACE_H_
 #define __PIXIEINTERFACE_H_
 
-#include "pixie16app_defs.h"
+#include <pixie16/pixie16.h>
 
 #define MIN_FIFO_READ 9
 
@@ -52,7 +52,6 @@ const int CCSRA_SUMMED_SINGLE_EVENT = 18;
 
 class PixieInterface {
 public:
-    static const size_t STAT_SIZE = N_DSP_PAR - DSP_IO_BORDER;
     static const size_t HISTO_SIZE = MAX_HISTOGRAM_LENGTH;
 #ifdef PIF_CATCHER
     enum CatcherModes {PC_STANDARD, PC_REJECT, PC_HYBRID, PC_ACCEPT};
@@ -61,7 +60,7 @@ public:
     typedef uint32_t word_t;
     typedef uint16_t halfword_t;
 
-    typedef word_t stats_t[STAT_SIZE];
+    typedef std::vector<word_t> stats_t;
 
     class Histogram {
     public:
@@ -231,7 +230,7 @@ private:
 
     static const size_t MAX_MODULES = 14;
     static const size_t CONFIG_LINE_LENGTH = 80;
-    static const size_t TRACE_LENGTH = RANDOMINDICES_LENGTH;
+    static const size_t TRACE_LENGTH = MAX_ADC_TRACE_LEN;
 
 #ifdef PIF_CATCHER
     void CatcherMessage(void);

--- a/Acquisition/Interface/source/CMakeLists.txt
+++ b/Acquisition/Interface/source/CMakeLists.txt
@@ -4,8 +4,7 @@ set(Interface_SOURCES PixieInterface.cpp Lock.cpp)
 add_library(PixieInterface STATIC ${Interface_SOURCES})
 
 #Order is important, XIA before PLX
-target_link_libraries(PixieInterface PaassCoreStatic ${XIA_LIBRARIES}
-        ${PLX_LIBRARIES})
+target_link_libraries(PixieInterface PaassCoreStatic ${PIXIESDK_PIXIE16_LIBRARIES} ${PLX_STATIC_LIB})
 
 set(Support_SOURCES PixieSupport.cpp)
 add_library(PixieSupport STATIC ${Support_SOURCES})

--- a/Acquisition/Interface/source/PixieInterface.cpp
+++ b/Acquisition/Interface/source/PixieInterface.cpp
@@ -10,8 +10,6 @@
 
 #include <sys/time.h>
 
-#include "pixie16app_export.h"
-
 #include "Display.h"
 #include "PixieInterface.h"
 
@@ -126,9 +124,8 @@ PixieInterface::PixieInterface(const char *fn) : lock("PixieInterface") {
         }
         exit(EXIT_FAILURE);
     }
-    //Overwrite the default path 'pxisys.ini' with the one specified in the scan file.
-    PCISysIniFile = configStrings["global"]["CrateConfig"].c_str();
 
+    statistics = stats_t(Pixie16GetStatisticsSize(), 0);
 }
 
 PixieInterface::~PixieInterface() {
@@ -658,7 +655,7 @@ bool PixieInterface::ReadSglChanTrace(unsigned short *buf, unsigned long sz,
 }
 
 bool PixieInterface::GetStatistics(unsigned short mod) {
-    retval = Pixie16ReadStatisticsFromModule(statistics, mod);
+    retval = Pixie16ReadStatisticsFromModule(statistics.data(), mod);
 
     if (retval < 0) {
         cout << WarningStr("Error reading statistics from module ") << mod
@@ -670,23 +667,23 @@ bool PixieInterface::GetStatistics(unsigned short mod) {
 }
 
 double PixieInterface::GetInputCountRate(int mod, int chan) {
-    return Pixie16ComputeInputCountRate(statistics, mod, chan);
+    return Pixie16ComputeInputCountRate(statistics.data(), mod, chan);
 }
 
 double PixieInterface::GetOutputCountRate(int mod, int chan) {
-    return Pixie16ComputeOutputCountRate(statistics, mod, chan);
+    return Pixie16ComputeOutputCountRate(statistics.data(), mod, chan);
 }
 
 double PixieInterface::GetLiveTime(int mod, int chan) {
-    return Pixie16ComputeLiveTime(statistics, mod, chan);
+    return Pixie16ComputeLiveTime(statistics.data(), mod, chan);
 }
 
 double PixieInterface::GetRealTime(int mod) {
-    return Pixie16ComputeRealTime(statistics, mod);
+    return Pixie16ComputeRealTime(statistics.data(), mod);
 }
 
 double PixieInterface::GetProcessedEvents(int mod) {
-    return Pixie16ComputeProcessedEvents(statistics, mod);
+    return Pixie16ComputeProcessedEvents(statistics.data(), mod);
 }
 
 bool PixieInterface::StartHistogramRun(unsigned short mode) {
@@ -764,7 +761,7 @@ unsigned long PixieInterface::CheckFIFOWords(unsigned short mod)
     cout << WarningStr("Error checking FIFO status in module ") << mod << endl;
     return 0;
   }
- 
+
     return nWords + extraWords[mod].size();
 }
 

--- a/Acquisition/Interface/source/PixieSupport.cpp
+++ b/Acquisition/Interface/source/PixieSupport.cpp
@@ -5,11 +5,11 @@
 #include <cmath>
 #include <unistd.h>
 
+#include <pixie16/pixie16.h>
+
 #include "Display.h"
 
 #include "PixieSupport.h"
-#include "pixie16app_defs.h"
-#include "pixie16app_export.h"
 
 std::string PadStr(const std::string &input_, int width_) {
     std::string output = input_;

--- a/Acquisition/Setup/source/copy_params.cpp
+++ b/Acquisition/Setup/source/copy_params.cpp
@@ -8,7 +8,7 @@
 
 #include <cstdlib>
 
-#include "pixie16app_export.h"
+#include <pixie16/pixie16.h>
 
 #include "Display.h"
 #include "PixieInterface.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ mark_as_advanced(PAASS_EXPORT_COMPILE_COMMANDS)
 if(PAASS_EXPORT_COMPILE_COMMANDS)
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "Generates compile_commands.json, needed for some IDEs among other things" FORCE)
 else ()
-    set(CMAKE_EXPORT_COMPILE_COMMANDS OFF CACHE BOOL "Generates compile_commands.json, needed for some IDEs among other things" FORCE)   
+    set(CMAKE_EXPORT_COMPILE_COMMANDS OFF CACHE BOOL "Generates compile_commands.json, needed for some IDEs among other things" FORCE)
 endif (PAASS_EXPORT_COMPILE_COMMANDS)
 
 #------------------------------------------------------------------------------
@@ -88,16 +88,16 @@ endif (PAASS_USE_DAMM)
 #------------------------------------------------------------------------------
 #Find packages needed for the software.
 #Load additional find_package scripts.
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/Cmake/modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/Cmake/modules/" "$ENV{XIA_PIXIE_SDK}/cmake/modules")
 
 #Find thread library for poll2 and scanLib
 find_package(Threads REQUIRED)
 
 #Find the PLX Library
-find_package(PLX)
+find_package(BroadcomAPI)
 
 #Find the Pixie Firmware
-find_package(XIA)
+find_package(PixieSDK)
 
 #Find curses library used for pretty much everything at this point.
 if (PAASS_USE_NCURSES)
@@ -125,16 +125,17 @@ if (PAASS_BUILD_ACQ)
         set(PAASS_BUILD_ACQ OFF CACHE BOOL "Build and install Acquisition" FORCE)
     else (PLX_FOUND OR XIA_FOUND)
         #Find the PLX Library
-        find_package(PLX REQUIRED)
+        find_package(BroadcomAPI REQUIRED)
+        include_directories(${PLX_INCLUDE_DIR})
         link_directories(${PLX_LIBRARY_DIR})
 
         #Find the Pixie Firmware
-        find_package(XIA REQUIRED)
-        include_directories(${XIA_INCLUDE_DIR})
-        link_directories(${XIA_LIBRARY_DIR})
+        find_package(PixieSDK REQUIRED)
+        include_directories(${PIXIESDK_INCLUDE_DIR})
+        link_directories(${PIXIESDK_LIBRARY_DIR})
 
         #Create pixie.cfg and copy slot_def.set as well as default.set to current.set
-        XIA_CONFIG()
+        #XIA_CONFIG()
     endif ()
     set(PAASS_BUILD_ACQ_ATTEMPTED ON CACHE INTERNAL "Build Suite Attempted")
 endif (PAASS_BUILD_ACQ)


### PR DESCRIPTION
Made the minimal changes necessary to compile against the latest XIA PixieSDK libraries. These changes use the `Pixie16Api.so` library to provide an interface to the C++ framework. 

**Note**: This commit disabled the automatic poll2 configuration file generation. 