### PR TITLE
ScanInterface:: Fix to utkscan segfaulting with ldfs on high chunk count spills

### DIFF
--- a/Analysis/ScanLibraries/source/ScanInterface.cpp
+++ b/Analysis/ScanLibraries/source/ScanInterface.cpp
@@ -594,8 +594,9 @@ void ScanInterface::RunControl() {
             bool full_spill;
             bool bad_spill;
             unsigned int nBytes;
-
-            if (!dry_run_mode) { data = new unsigned int[250000]; }
+              
+            const unsigned dataSize = 2500000;
+            if (!dry_run_mode) { data = new unsigned int[dataSize]; }
 
             // Reset the buffer reader to default values.
             databuff.Reset();


### PR DESCRIPTION
For example, FDSi MTAS SiPm implant with forced anode readout or FDSi VANDLE in doubles with a hot source and low thresholds. We were not allocating enough memory to read the data into. This was NOT an issue with scanor because it just reads 8192 words at a time (rather than a full spill) and passes it up as chunks. This will need a more permanent fix with a vector at a later date. Thanks to T. Ruland for finding and fixing this.