### PR TITLE
Fix memory bloat from threaded his writer

### DIFF
--- a/Analysis/Utkscan/CMakeLists.txt
+++ b/Analysis/Utkscan/CMakeLists.txt
@@ -16,6 +16,13 @@ mark_as_advanced(PAASS_UTKSCAN_TREE_DEBUG)
 mark_as_advanced(PAASS_UTKSCAN_VERBOSE)
 mark_as_advanced(PAASS_OVERRIDE_EXE_PREFIX)
 
+#-------------------------------------------------------------------------------
+# want to be able to turn the threaded behavior of UtkScan::HisFileWriter
+option(UTKSCAN_NO_HIS_THREAD "Disable using a thread for writing the Damm histograms with UtkScan" OFF)
+if(UTKSCAN_NO_HIS_THREAD)
+    add_compile_definitions(NO_HIS_THREAD)
+endif(UTKSCAN_NO_HIS_THREAD)
+
 # newreadout is needed to account for a change to pixie16 readout
 # structure change on 03/20/08. Is is REQUIRED!!
 add_definitions(-D newreadout)

--- a/Analysis/Utkscan/core/include/HisFile.hpp
+++ b/Analysis/Utkscan/core/include/HisFile.hpp
@@ -199,6 +199,7 @@ protected:
     std::ifstream drr; /// The input .drr file
     std::ifstream his; /// The input .his file
 
+    std::map<unsigned long long, std::pair<unsigned int, bool>> waiting_writes; 
     int hists_processed; /// The number of histograms which have been processed
     int err_flag; /// Integer value for storing error information
 
@@ -340,7 +341,6 @@ public:
 
 struct WriteQueueObject
 {
-
     /// @brief Location in the file that needs to be written to
     unsigned long long bufferLocation;
     /// @brief If the drr_entry for the histogram indicates that this histogram is integer valued
@@ -447,7 +447,6 @@ class HisFileWriter final
                 FlushWrites();
                 usleep(10);
             }
-            Finalize();
         }
 };
 
@@ -474,9 +473,10 @@ private:
     /// Find the specified .drr entry in the drr list using its histogram id
     std::shared_ptr<drr_entry> find_drr_in_list(unsigned int hisID_);
 
-    /// Enqueues a write in the output file with a 
-    void EnqueueWrite(std::shared_ptr<drr_entry> entry, unsigned int bin, unsigned int weight);
 
+    /// @brief Pushes a WriteQueueObject to the 
+    /// @param obj 
+    void PushWrite(WriteQueueObject obj);
 public:
     OutputHisFile();
 

--- a/Analysis/Utkscan/core/include/HisFile.hpp
+++ b/Analysis/Utkscan/core/include/HisFile.hpp
@@ -445,7 +445,6 @@ class HisFileWriter final
             {
                 ProcessQueue();
                 FlushWrites();
-                usleep(10);
             }
         }
 };


### PR DESCRIPTION
### Implements the following changes
1. HisFileWriter: waiting_writes is now emptied before getting events from the main thread instead of writing a limited amount of events at a time. 
    * This gets rid of the large wait time and the memory bloat that was associated with the write queue. Before, it was not uncommon to see 5GB of memory in use as reported by htop. 
Memory usage now tops out at around 600MB, but has some periodic hitching when the main thread cannot get the lock for the write queue. This could probably be cured through the use of a spin lock or atomics, but in favor of being able to support systems that don't have C++14 or newer available, I think it's unwise. In the case that someone less familiar with concurrent computing ever has to touch this code, it'd also be less obvious why things are being done that way.
Overall, finalize() times for the threaded HisWriter are now on the order of 10's of microseconds, down from 1-5 minutes depending on the speed of the storage, so I consider this a win. 
2. utkscan CmakeLists: Add option for not using the threaded his file writer. Off by default.

3. OutputHisFile: Add compile time condition to not use the threaded version of the his file output.
    * This will allow utkscan to function in an environment that is very memory constrained, such as 55kb of memory in use on Ubuntu 20 LTS.
    * Runtimes with this are on the order of 750 seconds on my laptop, so faster but results may vary depending on the system.
